### PR TITLE
Add redirects for openapi and javadoc to /apidocs

### DIFF
--- a/static/javadoc/index.html
+++ b/static/javadoc/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>                                                                 
+<html lang="en">                                                                
+    <head>                                                                      
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=/apidocs/javadoc" />       
+        <link rel="canonical" href="/apidocs/javadoc" />                     
+    </head>                                                                                                                                                                   
+    <body>                                                                      
+        <h1>                                                                    
+            The page been moved to <a href="/apidocs/javadoc">/apidocs/javadoc</a>
+        </h1>                                                                   
+    </body>                                                                     
+</html>

--- a/static/openapi/index.html
+++ b/static/openapi/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>                                                                 
+<html lang="en">                                                                
+    <head>                                                                      
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=/apidocs/openapi" />       
+        <link rel="canonical" href="/apidocs/openapi" />                     
+    </head>                                                                                                                                                                   
+    <body>                                                                      
+        <h1>                                                                    
+            The page been moved to <a href="/apidocs/openapi">/apidocs/openapi</a>
+        </h1>                                                                   
+    </body>                                                                     
+</html>


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>