### PR TITLE
[DOCUMENT] add openlineage's common env variables to the doc and create links

### DIFF
--- a/docs/client/java.md
+++ b/docs/client/java.md
@@ -47,6 +47,10 @@ Use the following options to configure the client:
 > **Note:** By default, the client will give you sane defaults, but you can easily override them.
 >
 
+### Environment Variables
+
+The list of available environment varaibles can be found [here](../development/developing#environment-variables).
+
 `YAML`
 
 ```yaml

--- a/docs/client/python.md
+++ b/docs/client/python.md
@@ -47,6 +47,10 @@ transport:
 
 The type property (required) is a fully qualified class name that can be imported.
 
+### Environment Variables
+
+The list of available environment varaibles can be found [here](../development/developing#environment-variables).
+
 ### Built-in Transport Types
 
 ##### HTTP

--- a/docs/development/developing.md
+++ b/docs/development/developing.md
@@ -17,6 +17,17 @@ For [Python](../client/python.md) and [Java](../client/java.md), we've created c
 Getting lineage from systems like BigQuery or Redshift isn't necessarily tied to orchestrator or processing engine you're using. For this reason, we've extracted
 that functionality from our Airflow library and [packaged it for separate use](https://pypi.org/project/openlineage-integration-common/). 
 
+### Environment Variables
+
+The following environment variables are available commonly for both Java and Python languages.
+
+|Name|Description|Since|
+|---|---|---|
+|OPENLINEAGE_API_KEY|The optional API key to be set on each lineage request. This will be set as a Bearer token in case authentication is required.||
+|OPENLINEAGE_CONFIG|The optional path to locate the configuration file. The configuration file is in YAML format. Example: `openlineage.yml`||
+|OPENLINEAGE_DISABLED|When set to `true`, will prevent OpenLineage from emitting events to the receiving backend|0.9.0|
+|OPENLINEAGE_URL|The URL for the HTTP transport of where to emit lineage events to. If not yet, no lineage data will be emitted. Example: `http://localhost:8080`||
+
 ### SQL parser
 
 We've created SQL parser that allows you to extract lineage from SQL statements. The parser is implemented in Rust, however, it's also available as a [Python library](https://pypi.org/project/openlineage-sql/).

--- a/docs/integrations/airflow/airflow.md
+++ b/docs/integrations/airflow/airflow.md
@@ -41,12 +41,22 @@ Simplest one is to use `OPENLINEAGE_URL` environment variable.
 For example, to send OpenLineage events to a local instance of Marquez, use:
 
 ```bash
-OPENLINEAGE_AIRFLOW=http://localhost:5000
+OPENLINEAGE_URL=http://localhost:5000
 ```
 
 To set up additional configuration, or send events to other targets than HTTP server (like Kafka topic) take a look at [client configuration.](../../client/python.md)
 
 If you use older version of Airflow than 2.3.0, [additional configuration is required](older.md).
+
+### Environment Variables
+
+The following environment variables are available specifically for Airflow integration.
+
+|Name|Description|Since|
+|---|---|---|
+|OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE|Set to `False` if you want source code of callables provided in PythonOperator or BashOperator `NOT` to be included in OpenLineage events||
+|OPENLINEAGE_EXTRACTORS|The optional list of extractors class in case you need to use custom extractors.<br/>Example: `OPENLINEAGE_EXTRACTORS=full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass`||
+|OPENLINEAGE_NAMESPACE|The optional namespace that the lineage data belongs to. If not specified, defaults to `default`||
 
 #### USAGE
 


### PR DESCRIPTION
# What this is about #
This PR adds an easy to read 'environment variables' table that can be used with OpenLineage.
This information has been scattered around the variable docs and Readme's and therefore, did not have any location in doc that user can easily see and understand.

Also, added integration specific env. variable table (for Airflow) which provides more concise usage.

Resolves: #46 

Signed-off-by: howardyoo <howardyoo@gmail.com>