### PR TITLE
DOC: added additional information about sql parser's `dialect` option.

### DIFF
--- a/docs/development/sql.md
+++ b/docs/development/sql.md
@@ -50,6 +50,8 @@ Optional `dialect` can be specified when using the parser to specify a specific 
 - snowflake
 - sqlite
 
+If no dialect is specified, the dialect defaults to `generic` which parses generic SQL statements.
+
 ### Default databases and schemas
 
 SQL processing engines and databases sometimes rely on some _implicit_ information. For example, they often allow you to set current database or schema, instead of forcing

--- a/docs/development/sql.md
+++ b/docs/development/sql.md
@@ -36,6 +36,20 @@ def parse(
 ) -> Optional[SqlMeta] 
 ```
 
+### SQL dialects 
+
+Optional `dialect` can be specified when using the parser to specify a specific flavor of SQL statement that is required to be parsed. The following dialects are currently available:
+
+- ansi
+- bigquery
+- hive
+- mssql
+- mysql
+- postgres
+- postgresql
+- snowflake
+- sqlite
+
 ### Default databases and schemas
 
 SQL processing engines and databases sometimes rely on some _implicit_ information. For example, they often allow you to set current database or schema, instead of forcing


### PR DESCRIPTION
Signed-off-by: howardyoo <howardyoo@gmail.com>

closes: #49 

This fix adds 'dialect' options of sql parser library.
User may need to specify different `dialects` to use the parser to parse for proper SQL statements.
