### PR TITLE
[SQL] added redshift dialect to sql doc

### DIFF
--- a/docs/development/sql.md
+++ b/docs/development/sql.md
@@ -47,6 +47,7 @@ Optional `dialect` can be specified when using the parser to specify a specific 
 - mysql
 - postgres
 - postgresql
+- redshift
 - snowflake
 - sqlite
 


### PR DESCRIPTION
This PR is related to https://github.com/OpenLineage/OpenLineage/issues/1062
Since the PR is closed, we should add `redshift` to the list of supported dialects of sql parser.

Signed-off-by: howardyoo <howardyoo@gmail.com>