### PR TITLE
[DOC] Added links to api documentation (openapi, javadoc)

### DIFF
--- a/docs/development/developing/developing.md
+++ b/docs/development/developing/developing.md
@@ -12,6 +12,11 @@ However, OpenLineage project also provides libraries you could use to write your
 
 For [Python](../../client/python.md) and [Java](../../client/java.md), we've created clients that you can use to properly create and emit OpenLineage events to HTTP, Kafka, and other consumers.
 
+### API Documentation
+
+- [OpenAPI documentation](https://openlineage.io/apidocs/openapi/)
+- [Java Doc](https://openlineage.io/apidocs/javadoc/)
+
 ### Common Library (Python)
 
 Getting lineage from systems like BigQuery or Redshift isn't necessarily tied to orchestrator or processing engine you're using. For this reason, we've extracted
@@ -26,7 +31,7 @@ The following environment variables are available commonly for both Java and Pyt
 |OPENLINEAGE_API_KEY|The optional API key to be set on each lineage request. This will be set as a Bearer token in case authentication is required.||
 |OPENLINEAGE_CONFIG|The optional path to locate the configuration file. The configuration file is in YAML format. Example: `openlineage.yml`||
 |OPENLINEAGE_DISABLED|When set to `true`, will prevent OpenLineage from emitting events to the receiving backend|0.9.0|
-|OPENLINEAGE_URL|The URL for the HTTP transport of where to emit lineage events to. If not yet, no lineage data will be emitted. Example: `http://localhost:8080`||
+|OPENLINEAGE_URL|The URL for the HTTP transport of where to emit lineage events to. If not yet, no lineage data will be emitted, and event data (JSON) will be written to standard output. Example: `http://localhost:8080`||
 
 ### SQL parser
 


### PR DESCRIPTION
# What is this PR about
fixes: #69 
Added links to api documentation under development section, so that people who wants to learn more about api can reach there.

Signed-off-by: OpenLineage deploy bot <openlineage-bot-key@openlineage.io>