### PR TITLE
add proper titles to releases

### DIFF
--- a/docs/Releases/0_10_0.md
+++ b/docs/Releases/0_10_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.10.0
 sidebar_position: 12
 ---
 

--- a/docs/Releases/0_11_0.md
+++ b/docs/Releases/0_11_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.11.0
 sidebar_position: 11
 ---
 

--- a/docs/Releases/0_12_0.md
+++ b/docs/Releases/0_12_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.12.0
 sidebar_position: 10
 ---
 

--- a/docs/Releases/0_13_0.md
+++ b/docs/Releases/0_13_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.13.0
 sidebar_position: 9
 ---
 

--- a/docs/Releases/0_13_1.md
+++ b/docs/Releases/0_13_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.13.1
 sidebar_position: 8
 ---
 

--- a/docs/Releases/0_14_0.md
+++ b/docs/Releases/0_14_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.14.0
 sidebar_position: 7
 ---
 

--- a/docs/Releases/0_14_1.md
+++ b/docs/Releases/0_14_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.14.1
 sidebar_position: 6
 ---
 

--- a/docs/Releases/0_15_1.md
+++ b/docs/Releases/0_15_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.15.1
 sidebar_position: 5
 ---
 

--- a/docs/Releases/0_16_1.md
+++ b/docs/Releases/0_16_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.16.1
 sidebar_position: 4
 ---
 

--- a/docs/Releases/0_17_0.md
+++ b/docs/Releases/0_17_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.17.0
 sidebar_position: 3
 ---
 

--- a/docs/Releases/0_18_0.md
+++ b/docs/Releases/0_18_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.18.0
 sidebar_position: 2
 ---
 

--- a/docs/Releases/0_19_2.md
+++ b/docs/Releases/0_19_2.md
@@ -1,4 +1,5 @@
 ---
+title: 0.19.2
 sidebar_position: 1
 ---
 

--- a/docs/Releases/0_1_0.md
+++ b/docs/Releases/0_1_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.1.0
 sidebar_position: 29
 ---
 

--- a/docs/Releases/0_2_0.md
+++ b/docs/Releases/0_2_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.2.0
 sidebar_position: 28
 ---
 

--- a/docs/Releases/0_2_1.md
+++ b/docs/Releases/0_2_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.2.1
 sidebar_position: 27
 ---
 

--- a/docs/Releases/0_2_2.md
+++ b/docs/Releases/0_2_2.md
@@ -1,4 +1,5 @@
 ---
+title: 0.2.2
 sidebar_position: 26
 ---
 

--- a/docs/Releases/0_2_3.md
+++ b/docs/Releases/0_2_3.md
@@ -1,4 +1,5 @@
 ---
+title: 0.2.3
 sidebar_position: 25
 ---
 

--- a/docs/Releases/0_3_0.md
+++ b/docs/Releases/0_3_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.3.0
 sidebar_position: 24
 ---
 

--- a/docs/Releases/0_3_1.md
+++ b/docs/Releases/0_3_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.3.1
 sidebar_position: 23
 ---
 

--- a/docs/Releases/0_4_0.md
+++ b/docs/Releases/0_4_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.4.0
 sidebar_position: 22
 ---
 

--- a/docs/Releases/0_5_1.md
+++ b/docs/Releases/0_5_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.5.1
 sidebar_position: 21
 ---
 

--- a/docs/Releases/0_5_2.md
+++ b/docs/Releases/0_5_2.md
@@ -1,4 +1,5 @@
 ---
+title: 0.5.2
 sidebar_position: 20
 ---
 

--- a/docs/Releases/0_6_0.md
+++ b/docs/Releases/0_6_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.6.0
 sidebar_position: 19
 ---
 

--- a/docs/Releases/0_6_1.md
+++ b/docs/Releases/0_6_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.6.1
 sidebar_position: 18
 ---
 

--- a/docs/Releases/0_6_2.md
+++ b/docs/Releases/0_6_2.md
@@ -1,4 +1,5 @@
 ---
+title: 0.6.2
 sidebar_position: 17
 ---
 

--- a/docs/Releases/0_7_1.md
+++ b/docs/Releases/0_7_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.7.1
 sidebar_position: 16
 ---
 

--- a/docs/Releases/0_8_1.md
+++ b/docs/Releases/0_8_1.md
@@ -1,4 +1,5 @@
 ---
+title: 0.8.1
 sidebar_position: 15
 ---
 

--- a/docs/Releases/0_8_2.md
+++ b/docs/Releases/0_8_2.md
@@ -1,4 +1,5 @@
 ---
+title: 0.8.2
 sidebar_position: 14
 ---
 

--- a/docs/Releases/0_9_0.md
+++ b/docs/Releases/0_9_0.md
@@ -1,4 +1,5 @@
 ---
+title: 0.9.0
 sidebar_position: 13
 ---
 


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

No titles were specified for the release files, so in each case Docusaurus was using the heading, which also had the date. This adds a cleaner title to each release file, so only the release number is displayed in the sidenav.

![Screenshot 2023-01-19 at 09 34 13](https://user-images.githubusercontent.com/68482867/213469692-8fa32464-7550-476b-bda6-24383b059a13.png)
