### PR TITLE
Update package name in Kafka instructions

### DIFF
--- a/docs/client/python.md
+++ b/docs/client/python.md
@@ -65,7 +65,7 @@ The list of available environment varaibles can be found [here](../development/d
 ##### Kafka
 
 Kafka transport requires `confluent-kafka` package to be additionally installed.
-It can be installed also by specifying kafka client extension: `pip install openlineage-client[kafka]` 
+It can be installed also by specifying kafka client extension: `pip install openlineage-python[kafka]` 
 
 - type - string (required)
 - config - string containing a Kafka producer config (required)


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

I believe the correct package is `openlineage-python[kafka]`.