### PR TITLE
Update Airflow versions and adjust some mentions due to removed support of 1.10.

### DIFF
--- a/docs/development/developing/python/tests/airflow.md
+++ b/docs/development/developing/python/tests/airflow.md
@@ -7,6 +7,8 @@ OpenLineage provides an integration with Apache Airflow. As Airflow is actively 
 * 2.1.4 (2.0+ upgrade)
 * 2.2.4
 * 2.3.4 (TaskListener API introduced)
+* 2.4.3
+* 2.5.0
 
 ### Unit tests
 In order to make running unit tests against multiple Airflow versions easier there is possibility to use [tox](https://tox.wiki/).
@@ -23,6 +25,8 @@ that should list:
 py3-airflow-2.1.4
 py3-airflow-2.2.4
 py3-airflow-2.3.4
+py3-airflow-2.4.3
+py3-airflow.2.5.0
 ```
 Then you can run tests in chosen environment, e.g.:
 ```

--- a/docs/integrations/airflow/extractors/custom-extractors.md
+++ b/docs/integrations/airflow/extractors/custom-extractors.md
@@ -74,9 +74,6 @@ OPENLINEAGE_EXTRACTORS: >-
   full.path.to.SecondExtractor
 ``` 
 
-Second method to register extractors - as a workaround for Airflow 1.10.x only - is to register all additional operator-extractor pairings by 
-providing `lineage_custom_extractors` argument in `openlineage.airflow.DAG`.
-
 ## Adding extractor to OpenLineage Airflow integration package
 
 All Openlineage extractors are defined in [this path](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/extractors).

--- a/docs/integrations/airflow/extractors/default-extractors.md
+++ b/docs/integrations/airflow/extractors/default-extractors.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Default extractors
 
-Default extractors are a new way in Airflow 2.3+ and OpenLineage 0.17.0+ to easily add lineage to your data pipelines by modifying your Airflow operators directly. This means custom operators—built in house or forked from another project—can provide you and your team with lineage data without having to modify the OpenLineage project directly, with data sent to your lineage backend of choice, most commonly using the `OPENLINEAGE_URL` environment variable.
+Default extractors are a new way in OpenLineage 0.17.0+ to easily add lineage to your data pipelines by modifying your Airflow operators directly. This means custom operators—built in house or forked from another project—can provide you and your team with lineage data without having to modify the OpenLineage project directly, with data sent to your lineage backend of choice, most commonly using the `OPENLINEAGE_URL` environment variable.
 
 The default extractor works a bit differently under the hood than other extractors. While extractors in the OpenLineage project have a getter method for operator names that they’re associated with, the default extractor looks for two specific methods in the operator itself and will call them directly if found. This means that the implementation for the extractor is just two methods in your operator.
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

This PR removes some mentions of no longer existing solutions. Also updates list of Airflow versions in CI.

In default extractor page there's untrue mention that may suggest default extractor works only in Airflow 2.3+.