### PR TITLE
Reflect recent updates of the Airflow integration

### DIFF
--- a/docs/integrations/about.md
+++ b/docs/integrations/about.md
@@ -36,7 +36,7 @@ This matrix shows which data sources are known to work with each integration, al
 
 | Platform	| Version	| Data Sources |
 |:-------------------|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Apache Airflow     | 1.10+<br />2.0+                | PostgreSQL<br />MySQL<br />Snowflake<br />Amazon Athena<br />Amazon Redshift<br />Amazon SageMaker<br />Amazon S3 Copy<br />Google BigQuery<br />Great Expectations<br />SFTP      |
+| Apache Airflow     | 1.10+<br />2.0+                | PostgreSQL<br />MySQL<br />Snowflake<br />Amazon Athena<br />Amazon Redshift<br />Amazon SageMaker<br />Amazon S3 Copy and Transform<br />Google BigQuery<br />Google Cloud Storage<br />Great Expectations<br />SFTP<br />FTP      |
 | Apache Spark | 2.4+ | JDBC<br />HDFS<br />Google Cloud Storage<br />Google BigQuery<br />Amazon S3<br />Azure Blob Storage<br />Azure Data Lake Gen2<br />Azure Synapse |
 | dbt | 0.20+ | Snowflake<br /> Google BigQuery |
 


### PR DESCRIPTION
There was a PR to the website (https://github.com/OpenLineage/website/pull/99) to update this information, but the page was moved into this repo before it was merged. Sorry, Kengo.

This makes the same changes, but on the new page.