### PR TITLE
Serve pages from this repo instead

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: OpenLineage/OpenLineage.github.io
-          publish_branch: gh-pages  # default: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           cname: openlineage.io


### PR DESCRIPTION

Since we no longer have multiple websites (docs, spec, website) we can now serve all pages from this repo instead of publishing to `openlineage.github.io` repo.