### PR TITLE
FIX for styles (navigation icon, code blocks style in blog posts)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -89,6 +89,10 @@ a {
   font-weight: normal;
 }
 
+.navbar__item svg {
+  display: inline-block !important;
+}
+
 a.navbar__brand:hover {
   color: var(--ifm-navbar-link-color);
   text-decoration: none;
@@ -363,11 +367,8 @@ code .token-line {
 }
 
 #post-content pre {
-  overflow: scroll;
-  color: #fff;
-  background-color: #333;
   padding: 1rem;
-  margin: 2rem;
+  margin: 1rem;
 }
 
 .int-title {


### PR DESCRIPTION
Small fix for important style elements as inline icon for github in header and each code block in blog posts for light and dark theme.

@rossturk  please take a look and merge :) 