### PR TITLE
More small fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ const links = [
 ]
 
 const linksSocial = [
-  { href: 'https://fosstodon.org/@openlineage', label: 'Mastodon' },
+  { href: 'https://fosstodon.org/@openlineage', label: 'Mastodon', rel: 'me' },
   { href: 'https://twitter.com/OpenLineage', label: 'Twitter' },
   { href: 'http://bit.ly/OpenLineageSlack', label: 'Slack' },
   { href: 'https://github.com/OpenLineage/OpenLineage', label: 'GitHub' }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,11 +64,11 @@ const config = {
         blog: {
           blogTitle: 'Blog',
           blogDescription: 'Data lineage is the foundation for a new generation of powerful, context-aware data tools and best practices. OpenLineage enables consistent collection of lineage metadata, creating a deeper understanding of how data is produced and used.',
-          blogSidebarCount: 'ALL',
+          blogSidebarCount: 0,
           blogSidebarTitle: 'All our posts',
           feedOptions: {
             type: ['json'],
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} The Linux Foundation®. All rights reserved.`,
           },
         },
         pages: {

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -43,7 +43,7 @@ export default function () {
 const ListItem = ({ data }) => {
     return (
         <li className="inline-block mx-3 animated-link-parent">
-            <a href={data.to ? data.to : data.href} title={data.label}>
+            <a href={data.to ? data.to : data.href} title={data.label} rel={data.rel ? data.rel : ""}>
                 <span>{data.label}</span>
             </a>
         </li>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -15,8 +15,8 @@ These resources have been gathered to help new users learn about OpenLineage, or
 
 ## Docs
 
-* [OpenAPI specification](/apidocs/openapi)
-* [Java client documentation](/apidocs/javadoc)
+* [OpenAPI specification](/apidocs/openapi/)
+* [Java client documentation](/apidocs/javadoc/)
 
 ## Conference Talks
 

--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -15,7 +15,7 @@ export default function BlogListPageWrapper(props) {
   return (
     <Layout title={seoTitle} description={seoDescription}>
       <div className="container mx-auto px-0 pb-40">
-        <div className="px-4 py-12 text-center lg:py-14 lg:px-0">
+        <div className="px-4 py-12 text-center lg:py-14 lg:px-0 margin-vert--lg">
           <h2 className="text-color-1 text-5xl lg:text-4xl">
             Blog
           </h2>


### PR DESCRIPTION
This PR addresses the following:
* restore the `rel="me"` attribute to the Mastodon link in the footer, so verification works again
* turns off the sidebar on the blog pages
* makes the title on the blog landing page consistent with the vertical spacing of the other page titles
* adds trailing `/` to the API links in the resources page so they begin to work

Closes #136 