### PR TITLE
Shrink blog banners vertically

### DIFF
--- a/blog/0.1-release/index.mdx
+++ b/blog/0.1-release/index.mdx
@@ -8,7 +8,7 @@ description: We are pleased to announce the initial release of OpenLineage. This
 ---
 We are pleased to announce the initial release of OpenLineage. This release includes the core specification, data model, clients, and integrations with common data tools.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/backfilling-airflow-dags-using-marquez/index.mdx
+++ b/blog/backfilling-airflow-dags-using-marquez/index.mdx
@@ -8,7 +8,7 @@ description: In this blog post, we'll discuss how lineage metadata can be used t
 ---
 In this blog post, we'll discuss how lineage metadata can be used to automatically backfill DAGs with complex upstream and downstream dependencies.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/column-lineage/index.mdx
+++ b/blog/column-lineage/index.mdx
@@ -9,7 +9,7 @@ description: Column-level lineage helps organizations navigate a complex regulat
 
 Column-level lineage helps organizations navigate a complex regulatory landscape.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/data-agility-day/index.mdx
+++ b/blog/data-agility-day/index.mdx
@@ -8,7 +8,7 @@ description: At Data Agility Day 2021, Julien Le Dem and Kevin Mellott outlined 
 ---
 At Data Agility Day 2021, Julien Le Dem and Kevin Mellott outlined their approach to data lineage and discussed various approaches to implementing it in the real world.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/data-council-meetup/index.mdx
+++ b/blog/data-council-meetup/index.mdx
@@ -12,7 +12,7 @@ events that attract the best and brightest speakers in the data ecosystem, will
 be holding its only [conference of 2023](https://www.datacouncil.ai/austin) in 
 Austin, Texas, on March 28-30th, and OpenLineage will be there. 
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/data-lineage-meetup/index.mdx
+++ b/blog/data-lineage-meetup/index.mdx
@@ -9,7 +9,7 @@ description: The inaugural Data Lineage Meetup will take place on March 9th in P
 
 Join us on Thursday, March 9, 2023 from 6-8 pm in Providence, Rhode Island, to learn more about the present and future of OpenLineage. Meet other members of the ecosystem, learn about the project’s goals and fundamental design, and participate in a discussion about the future of the project. Bring your ideas and vision for OpenLineage!
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/dataquality_expectations_facet/index.mdx
+++ b/blog/dataquality_expectations_facet/index.mdx
@@ -8,7 +8,7 @@ description: Good data is paramount to making good decisions- but how can you tr
 ---
 Good data is paramount to making good decisions- but how can you trust the quality of your data and its dependencies?
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/dbt-with-marquez/index.mdx
+++ b/blog/dbt-with-marquez/index.mdx
@@ -8,7 +8,7 @@ description: Each time dbt runs, it generates a trove of metadata about datasets
 ---
 Each time dbt runs, it generates a trove of metadata about datasets and the work it performs with them. In this post, I’d like to show you how to harvest this metadata and put it to good use.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/explore-lineage-api/index.mdx
+++ b/blog/explore-lineage-api/index.mdx
@@ -8,7 +8,7 @@ description: Taking advantage of recent changes to the Marquez API, this post sh
 ---
 Taking advantage of recent changes to the Marquez API, this post shows how to diagnose job failures and explore the impact of code changes on downstream dependents.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/extending-with-facets/index.mdx
+++ b/blog/extending-with-facets/index.mdx
@@ -8,7 +8,7 @@ description: Facets are a self-contained definition of one aspect of a job, data
 ---
 Facets are a self-contained definition of one aspect of a job, dataset, or run at the time the event happened. They make the OpenLineage model extensible.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/extractors/index.mdx
+++ b/blog/extractors/index.mdx
@@ -8,7 +8,7 @@ description: Built-in support for custom extractors makes OpenLineage a highly a
 ---
 Built-in support for custom extractors makes OpenLineage a highly adaptable solution for pipelines that use Airflow.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/incubation-stage-lfai/index.mdx
+++ b/blog/incubation-stage-lfai/index.mdx
@@ -8,7 +8,7 @@ description: OpenLineage has achieved Incubation status with the LFAI & Data.
 ---
 OpenLineage has achieved Incubation status with the LFAI & Data.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/joining-lfai/index.mdx
+++ b/blog/joining-lfai/index.mdx
@@ -8,7 +8,7 @@ description: Becoming a LF AI & Data project ensures that OpenLineage can never 
 ---
 Becoming a LF AI & Data project ensures that OpenLineage can never belong to a company, or even a group of developers; it belongs to us all.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/manta-integration/index.mdx
+++ b/blog/manta-integration/index.mdx
@@ -8,7 +8,7 @@ description: Adopting OpenLineage as part of our portfolio allows MANTA to bring
 ---
 Adopting OpenLineage as part of our portfolio allows MANTA to bring detailed run-time lineage to our customers.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-at-northwestern-mutual/index.mdx
+++ b/blog/openlineage-at-northwestern-mutual/index.mdx
@@ -8,7 +8,7 @@ description: Northwestern Mutual is building an Enterprise Data Platform. In thi
 ---
 Northwestern Mutual is building an Enterprise Data Platform. In this guest blog, learn about the experiences and decisions that led them to embrace the OpenLineage and Marquez communities.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-egeria/index.mdx
+++ b/blog/openlineage-egeria/index.mdx
@@ -8,7 +8,7 @@ description: The Egeria project uses OpenLineage to enhance its production of ho
 ---
 The Egeria project uses OpenLineage to enhance its production of holistic metadata about an organization's operations.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-microsoft-purview/index.mdx
+++ b/blog/openlineage-microsoft-purview/index.mdx
@@ -8,7 +8,7 @@ description: A new collaboration between Microsoft and OpenLineage is making lin
 ---
 A new collaboration between Microsoft and OpenLineage is making lineage extraction possible for Azure Databricks and Microsoft Purview users.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-snowflake/index.mdx
+++ b/blog/openlineage-snowflake/index.mdx
@@ -8,7 +8,7 @@ description: The OpenLineage Adapter offers Snowflake's enterprise users a power
 ---
 The OpenLineage Adapter offers Snowflake's enterprise users a powerful tool for analyzing their pipelines.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-spark/index.mdx
+++ b/blog/openlineage-spark/index.mdx
@@ -8,7 +8,7 @@ description: Spark ushered in a brand new age of data democratization... and lef
 ---
 Spark ushered in a brand new age of data democratization... and left us with a mess of hidden dependencies, stale datasets, and failed jobs.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/openlineage-takes-inspiration-from-opentelemetry/index.mdx
+++ b/blog/openlineage-takes-inspiration-from-opentelemetry/index.mdx
@@ -8,7 +8,7 @@ description: The data world and the service world have many similarities but als
 ---
 The data world and the service world have many similarities but also a few crucial differences. 
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/operators-and-extractors-technical-deep-dive/index.mdx
+++ b/blog/operators-and-extractors-technical-deep-dive/index.mdx
@@ -8,7 +8,7 @@ description: A technical deep-dive on how the Airflow OSS and OpenLineage OSS pr
 ---
 A technical deep-dive on how the Airflow OSS and OpenLineage OSS projects interact. 
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/python-client/index.mdx
+++ b/blog/python-client/index.mdx
@@ -8,7 +8,7 @@ description: The Python client enables users to create custom integrations.
 ---
 The Python client enables users to create custom integrations.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/blog/whats-in-a-namespace/index.mdx
+++ b/blog/whats-in-a-namespace/index.mdx
@@ -8,7 +8,7 @@ description: Namespaces enable powerful insights into distributed workflows.
 ---
 Namespaces enable powerful insights into distributed workflows.
 
-![](./banner.svg#full-width)
+![](./banner.svg#banner)
 
 <!--truncate-->
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -479,3 +479,11 @@ html.docs-doc-page body {
 .pagination a.bg-gradient-primary:hover {
   color: white;
 }
+
+img[src*="#banner"] {
+  width: 100%;
+  height: 30px;
+  overflow: hidden;
+  object-fit: cover;
+  object-position: 25% 25%;
+}


### PR DESCRIPTION
In the new blog layout, the images are no longer in the background of the header. They are inline, and take up a lot of space.

This PR shrinks them by adding a new CSS style and updating each post. IMO this looks a bit better, and still retains the image element.

Before:
<img width="1002" alt="Screenshot 2023-03-30 at 8 03 24 PM" src="https://user-images.githubusercontent.com/1434475/228996962-f766958d-f2e8-4e8a-abac-5e175366b2b7.png">


After:
<img width="1018" alt="Screenshot 2023-03-30 at 8 02 40 PM" src="https://user-images.githubusercontent.com/1434475/228996875-b1501537-1898-416d-ad4b-570d5b8e17f6.png">
