### PR TITLE
Add Plausible Analytics for stats

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,6 +139,13 @@ const config = {
         respectPrefersColorScheme: false,
       },  
     }),
+
+  scripts:
+    [{
+      src: 'https://plausible.io/js/script.js',
+      defer: true,
+      'data-domain': 'openlineage.io',
+    }],
 };
 
 module.exports = config;


### PR DESCRIPTION
This was in place on the previous OpenLineage website, but we never deployed it for docs. Now we can have it for both!