### PR TITLE
Fix resources page links

### DIFF
--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -15,8 +15,8 @@ These resources have been gathered to help new users learn about OpenLineage, or
 
 ## Docs
 
-* [OpenAPI specification](/apidocs/openapi/)
-* [Java client documentation](/apidocs/javadoc/)
+* [OpenAPI specification](https://openlineage.io/apidocs/openapi/)
+* [Java client documentation](https://openlineage.io/apidocs/javadoc/)
 
 ## Conference Talks
 


### PR DESCRIPTION
These links behave oddly - going to the resources page and then clicking the API docs links will lead to a 404, but then a page refresh is successful. I think making these external links will work better.