### PR TITLE
release notes for 0.23.0 and bumped  position numbers for other releases

### DIFF
--- a/docs/releases/0_10_0.md
+++ b/docs/releases/0_10_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.10.0
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # 0.10.0 - 2022-6-24

--- a/docs/releases/0_11_0.md
+++ b/docs/releases/0_11_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.11.0
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # 0.11.0 - 2022-7-7

--- a/docs/releases/0_12_0.md
+++ b/docs/releases/0_12_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.12.0
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # 0.12.0 - 2022-8-1

--- a/docs/releases/0_13_0.md
+++ b/docs/releases/0_13_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.0
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # 0.13.0 - 2022-8-22

--- a/docs/releases/0_13_1.md
+++ b/docs/releases/0_13_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.1
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # 0.13.1 - 2022-8-25

--- a/docs/releases/0_14_0.md
+++ b/docs/releases/0_14_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.0
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # 0.14.0 - 2022-9-6

--- a/docs/releases/0_14_1.md
+++ b/docs/releases/0_14_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.1
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # 0.14.1 - 2022-9-7

--- a/docs/releases/0_15_1.md
+++ b/docs/releases/0_15_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.15.1
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # 0.15.1 - 2022-10-5

--- a/docs/releases/0_16_1.md
+++ b/docs/releases/0_16_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.16.1
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # 0.16.1 - 2022-11-3

--- a/docs/releases/0_17_0.md
+++ b/docs/releases/0_17_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.17.0
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # 0.17.0 - 2022-11-16

--- a/docs/releases/0_18_0.md
+++ b/docs/releases/0_18_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.18.0
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # 0.18.0 - 2022-12-8

--- a/docs/releases/0_19_2.md
+++ b/docs/releases/0_19_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.19.2
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # 0.19.2 - 2023-1-4

--- a/docs/releases/0_1_0.md
+++ b/docs/releases/0_1_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.1.0
-sidebar_position: 33
+sidebar_position: 34
 ---
 
 # 0.1.0 - 2021-8-13

--- a/docs/releases/0_20_4.md
+++ b/docs/releases/0_20_4.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.4
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # 0.20.4 - 2023-2-7

--- a/docs/releases/0_20_6.md
+++ b/docs/releases/0_20_6.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.6
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # 0.20.6 - 2023-2-10

--- a/docs/releases/0_21_1.md
+++ b/docs/releases/0_21_1.md
@@ -1,44 +1,44 @@
 ---
 title: 0.21.1
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 0.21.1 - 2023-3-2
 
 ### Added
-* **Clients: add `DEBUG` logging of events to transports** [`#1633`](https://github.com/OpenLineage/OpenLineage/pull/1633) by [@mobuchowski](https://github.com/mobuchowski)  
+* **Clients: add `DEBUG` logging of events to transports** [`#1633`](https://github.com/OpenLineage/OpenLineage/pull/1633) [@mobuchowski](https://github.com/mobuchowski)  
     *Ensures that the `DEBUG` loglevel on properly configured loggers will always log events, regardless of the chosen transport.*
-* **Spark: add `CustomEnvironmentFacetBuilder` class** [`#1545`](https://github.com/OpenLineage/OpenLineage/pull/1545) by ***New contributor*** [@Anirudh181001](https://github.com/Anirudh181001)  
+* **Spark: add `CustomEnvironmentFacetBuilder` class** [`#1545`](https://github.com/OpenLineage/OpenLineage/pull/1545) ***New contributor*** [@Anirudh181001](https://github.com/Anirudh181001)  
     *Enables the capture of custom environment variables from Spark.*
-* **Spark: introduce the new output visitors `AlterTableAddPartitionCommandVisitor` and `AlterTableSetLocationCommandVisitor`** [`#1629`](https://github.com/OpenLineage/OpenLineage/pull/1629) by ***New contributor*** [@nataliezeller1](https://github.com/nataliezeller1)  
+* **Spark: introduce the new output visitors `AlterTableAddPartitionCommandVisitor` and `AlterTableSetLocationCommandVisitor`** [`#1629`](https://github.com/OpenLineage/OpenLineage/pull/1629) ***New contributor*** [@nataliezeller1](https://github.com/nataliezeller1)  
     *Adds visitors for extracting table names from the Spark commands `AlterTableAddPartitionCommand` and `AlterTableSetLocationCommand`. The intended use case is a custom transport for the OpenMetadata lineage API.*
-* **Spark: add column lineage for JDBC relations** [`#1636`](https://github.com/OpenLineage/OpenLineage/pull/1636) by [@tnazarew](https://github.com/tnazarew)  
+* **Spark: add column lineage for JDBC relations** [`#1636`](https://github.com/OpenLineage/OpenLineage/pull/1636) [@tnazarew](https://github.com/tnazarew)  
     *Adds column lineage information to JDBC events with data extracted from query by the SQL parser.*
-* **SQL: add linux-aarch64 native library to Java SQL parser** [`#1664`](https://github.com/OpenLineage/OpenLineage/pull/1664) by [@mobuchowski](https://github.com/mobuchowski)  
+* **SQL: add linux-aarch64 native library to Java SQL parser** [`#1664`](https://github.com/OpenLineage/OpenLineage/pull/1664) [@mobuchowski](https://github.com/mobuchowski)  
     *Adds a Linux-ARM version of the native library. The Java SQL parser interface had only Linux-x64 and MacOS universal binary variants previously.*
 
 ### Changed
-* **Airflow: get table database in Athena extractor** [`#1631`](https://github.com/OpenLineage/OpenLineage/pull/1631) by ***New contributor*** [@rinzool](https://github.com/rinzool)  
+* **Airflow: get table database in Athena extractor** [`#1631`](https://github.com/OpenLineage/OpenLineage/pull/1631) ***New contributor*** [@rinzool](https://github.com/rinzool)  
     *Changes the extractor to get a table's database from the `table.schema` field or the operator default if the field is `None`.*
 
 ### Fixed
-* **dbt: add dbt `seed` to the list of dbt-ol events** [`#1649`](https://github.com/OpenLineage/OpenLineage/pull/1649) by ***New contributor*** [@pohek321](https://github.com/pohek321)  
+* **dbt: add dbt `seed` to the list of dbt-ol events** [`#1649`](https://github.com/OpenLineage/OpenLineage/pull/1649) ***New contributor*** [@pohek321](https://github.com/pohek321)  
     *Ensures that `dbt-ol test` no longer fails when run against an event seed.*
-* **Spark: make column lineage extraction in Spark support caching** [`#1634`](https://github.com/OpenLineage/OpenLineage/pull/1634) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+* **Spark: make column lineage extraction in Spark support caching** [`#1634`](https://github.com/OpenLineage/OpenLineage/pull/1634) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Collect column lineage from Spark logical plans that contain cached datasets.*
-* **Spark: add support for a deprecated config** [`#1586`](https://github.com/OpenLineage/OpenLineage/pull/1586) by [@tnazarew](https://github.com/tnazarew)  
+* **Spark: add support for a deprecated config** [`#1586`](https://github.com/OpenLineage/OpenLineage/pull/1586) [@tnazarew](https://github.com/tnazarew)  
     *Maps the deprecated `spark.openlineage.url` to `spark.openlineage.transport.url`.*
-* **Spark: add error message in case of null in url** [`#1590`](https://github.com/OpenLineage/OpenLineage/pull/1590) by [@tnazarew](https://github.com/tnazarew)  
+* **Spark: add error message in case of null in url** [`#1590`](https://github.com/OpenLineage/OpenLineage/pull/1590) [@tnazarew](https://github.com/tnazarew)  
     *Improves error logging in the case of undefined URLs.*
-* **Spark: collect complete event for really quick Spark jobs** [`#1650`](https://github.com/OpenLineage/OpenLineage/pull/1650) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
+* **Spark: collect complete event for really quick Spark jobs** [`#1650`](https://github.com/OpenLineage/OpenLineage/pull/1650) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
     *Improves the collecting of OpenLineage events on SQL complete in the case of quick operations.*
-* **Spark: fix input/outputs for one node `LogicalRelation` plans** [`#1668`](https://github.com/OpenLineage/OpenLineage/pull/1668) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+* **Spark: fix input/outputs for one node `LogicalRelation` plans** [`#1668`](https://github.com/OpenLineage/OpenLineage/pull/1668) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *For simple queries like `select col1, col2 from my_db.my_table` that do not write output, 
     the Spark plan contained just a single node, which was wrongly treated as both 
     an input and output dataset.*
-* **SQL: fix file existence check in build script for openlineage-sql-java** [`#1613`](https://github.com/OpenLineage/OpenLineage/pull/1613) by [@sekikn](https://github.com/sekikn)  
+* **SQL: fix file existence check in build script for openlineage-sql-java** [`#1613`](https://github.com/OpenLineage/OpenLineage/pull/1613) [@sekikn](https://github.com/sekikn)  
     *Ensures that the build script works if the library is compiled solely for Linux.*
 
 ### Removed
-* **Airflow: remove `JobIdMapping` and update macros to better support Airflow version 2+** [`#1645`](https://github.com/OpenLineage/OpenLineage/pull/1645) by [@JDarDagran](https://github.com/JDarDagran)  
+* **Airflow: remove `JobIdMapping` and update macros to better support Airflow version 2+** [`#1645`](https://github.com/OpenLineage/OpenLineage/pull/1645) [@JDarDagran](https://github.com/JDarDagran)  
     *Updates macros to use `OpenLineageAdapter`'s method to generate deterministic run UUIDs because using the `JobIdMapping` utility is incompatible with Airflow 2+.*

--- a/docs/releases/0_22_0.md
+++ b/docs/releases/0_22_0.md
@@ -1,36 +1,36 @@
 ---
 title: 0.22.0
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # 0.22.0 - 2023-4-3
 
 ### Added
-* **Spark: properties facet** [`#1717`](https://github.com/OpenLineage/OpenLineage/pull/1717) by [@tnazarew](https://github.com/tnazarew)    
+* **Spark: properties facet** [`#1717`](https://github.com/OpenLineage/OpenLineage/pull/1717) [@tnazarew](https://github.com/tnazarew)    
     *Adds a new facet to capture specified Spark properties.*
-* **SQL: SQLParser supports `alter`, `truncate` and `drop` statements** [`#1695`](https://github.com/OpenLineage/OpenLineage/pull/1695) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+* **SQL: SQLParser supports `alter`, `truncate` and `drop` statements** [`#1695`](https://github.com/OpenLineage/OpenLineage/pull/1695) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Adds support for the statements to the parser.*
-* **Common/SQL: provide public interface for openlineage_sql package** [`#1727`](https://github.com/OpenLineage/OpenLineage/pull/1727) by [@JDarDagran](https://github.com/JDarDagran)  
+* **Common/SQL: provide public interface for openlineage_sql package** [`#1727`](https://github.com/OpenLineage/OpenLineage/pull/1727) [@JDarDagran](https://github.com/JDarDagran)  
     *Provides a `.pyi` public interface file for providing typing hints.*
-* **Java client: add configurable headers to HTTP transport** [`#1718`](https://github.com/OpenLineage/OpenLineage/pull/1718) by [@tnazarew](https://github.com/tnazarew)    
+* **Java client: add configurable headers to HTTP transport** [`#1718`](https://github.com/OpenLineage/OpenLineage/pull/1718) [@tnazarew](https://github.com/tnazarew)    
     *Adds custom header handling to `HttpTransport` and the Spark integration.*
-* **Python client: create client from dictionary** [`#1745`](https://github.com/OpenLineage/OpenLineage/pull/1745) by [@JDarDagran](https://github.com/JDarDagran)  
+* **Python client: create client from dictionary** [`#1745`](https://github.com/OpenLineage/OpenLineage/pull/1745) [@JDarDagran](https://github.com/JDarDagran)  
     *Adds a new `from_dict` method to the Python client to support creating it from a dictionary.*
 
 ### Changed
-* **Spark: remove URL parameters for JDBC namespaces** [`#1708`](https://github.com/OpenLineage/OpenLineage/pull/1708) by [@tnazarew](https://github.com/tnazarew)      
+* **Spark: remove URL parameters for JDBC namespaces** [`#1708`](https://github.com/OpenLineage/OpenLineage/pull/1708) [@tnazarew](https://github.com/tnazarew)      
     *Makes the namespace value from an event conform to the naming convention specified in* [Naming.md](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md).
-* **Make `OPENLINEAGE_DISABLED` case-insensitive** [`#1705`](https://github.com/OpenLineage/OpenLineage/pull/1705) by [@jedcunningham](https://github.com/jedcunningham)  
+* **Make `OPENLINEAGE_DISABLED` case-insensitive** [`#1705`](https://github.com/OpenLineage/OpenLineage/pull/1705) [@jedcunningham](https://github.com/jedcunningham)  
     *Makes the environment variable for disabling OpenLineage in the Python client and Airflow integration case-insensitive.*
 
 ### Fixed
-* **Spark: fix missing BigQuery class in column lineage** [`#1698`](https://github.com/OpenLineage/OpenLineage/pull/1698) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+* **Spark: fix missing BigQuery class in column lineage** [`#1698`](https://github.com/OpenLineage/OpenLineage/pull/1698) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *The Spark integration now checks if the BigQuery classes are available on the classpath before attempting to use them.*
-* **DBT: throw `UnsupportedDbtCommand` when finding unsupported entry in `args.which`** [`#1724`](https://github.com/OpenLineage/OpenLineage/pull/1724) by [@JDarDagran](https://github.com/JDarDagran)  
+* **DBT: throw `UnsupportedDbtCommand` when finding unsupported entry in `args.which`** [`#1724`](https://github.com/OpenLineage/OpenLineage/pull/1724) [@JDarDagran](https://github.com/JDarDagran)  
     *Adjusts the `dbt-ol` script to detect DBT commands in `run_results.json` only.*
 
 ### Removed
-* **Spark: remove unnecessary warnings for column lineage** [`#1700`](https://github.com/OpenLineage/OpenLineage/pull/1700) by [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+* **Spark: remove unnecessary warnings for column lineage** [`#1700`](https://github.com/OpenLineage/OpenLineage/pull/1700) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Removes the warnings about `OneRowRelation` and `LocalRelation` nodes.*
-* **Spark: remove deprecated configs** [`#1711`](https://github.com/OpenLineage/OpenLineage/pull/1711) by [@tnazarew](https://github.com/tnazarew)    
+* **Spark: remove deprecated configs** [`#1711`](https://github.com/OpenLineage/OpenLineage/pull/1711) [@tnazarew](https://github.com/tnazarew)    
     *Removes support for deprecated configs.*

--- a/docs/releases/0_23_0.md
+++ b/docs/releases/0_23_0.md
@@ -1,0 +1,28 @@
+---
+title: 0.23.0
+sidebar_position: 1
+---
+
+# 0.23.0 - 2023-4-20
+
+### Added
+* **SQL: parser improvements to support: `copy into`, `create stage`, `pivot`** [`#1742`](https://github.com/OpenLineage/OpenLineage/pull/1742) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Adds support for additional syntax available in sqlparser-rs.*
+* **dbt: add support for snapshots** [`#1787`](https://github.com/OpenLineage/OpenLineage/pull/1787) [@JDarDagran](https://github.com/JDarDagran)  
+    *Adds support for this special kind of table representing type-2 Slowly Changing Dimensions.*
+
+### Changed
+* **Spark: change custom column lineage visitors** [`#1788`](https://github.com/OpenLineage/OpenLineage/pull/1788) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Makes the `CustomColumnLineageVisitor` interface public to support custom column lineage.*
+
+### Fixed
+* **Spark: fix null pointer in `JobMetricsHolder`** [`#1786`](https://github.com/OpenLineage/OpenLineage/pull/1786) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Adds a null check before running `put` to fix a NPE occurring in `JobMetricsHolder`*
+* **SQL: fix query with table generator** [`#1783`](https://github.com/OpenLineage/OpenLineage/pull/1783) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Allows `TableFactor::TableFunction` to support queries containing table functions.*
+* **SQL: fix rust code style bug** [`#1785`](https://github.com/OpenLineage/OpenLineage/pull/1785) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Fixes a minor style issue in `visitor.rs`.*
+
+### Removed
+* **Airflow: Remove explicit `pass` from several `extract_on_complete` methods** [`#1771`](https://github.com/OpenLineage/OpenLineage/pull/1771) [@JDarDagran](https://github.com/JDarDagran)  
+    *Removes the code from three extractors.*

--- a/docs/releases/0_2_0.md
+++ b/docs/releases/0_2_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.0
-sidebar_position: 32
+sidebar_position: 33
 ---
 
 # 0.2.0 - 2021-8-23

--- a/docs/releases/0_2_1.md
+++ b/docs/releases/0_2_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.1
-sidebar_position: 31
+sidebar_position: 32
 ---
 
 # 0.2.1 - 2021-8-27

--- a/docs/releases/0_2_2.md
+++ b/docs/releases/0_2_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.2
-sidebar_position: 30
+sidebar_position: 31
 ---
 
 # 0.2.2 - 2021-9-8

--- a/docs/releases/0_2_3.md
+++ b/docs/releases/0_2_3.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.3
-sidebar_position: 29
+sidebar_position: 30
 ---
 
 # 0.2.3 - 2021-10-7

--- a/docs/releases/0_3_0.md
+++ b/docs/releases/0_3_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.0
-sidebar_position: 28
+sidebar_position: 29
 ---
 
 # 0.3.0 - 2021-12-3

--- a/docs/releases/0_3_1.md
+++ b/docs/releases/0_3_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.1
-sidebar_position: 27
+sidebar_position: 28
 ---
 
 # 0.3.1 - 2021-12-3

--- a/docs/releases/0_4_0.md
+++ b/docs/releases/0_4_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.4.0
-sidebar_position: 26
+sidebar_position: 27
 ---
 
 # 0.4.0 - 2021-12-13

--- a/docs/releases/0_5_1.md
+++ b/docs/releases/0_5_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.1
-sidebar_position: 25
+sidebar_position: 26
 ---
 
 # 0.5.1 - 2022-1-18

--- a/docs/releases/0_5_2.md
+++ b/docs/releases/0_5_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.2
-sidebar_position: 24
+sidebar_position: 25
 ---
 
 # 0.5.2 - 2022-2-10

--- a/docs/releases/0_6_0.md
+++ b/docs/releases/0_6_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.0
-sidebar_position: 23
+sidebar_position: 24
 ---
 
 # 0.6.0 - 2022-3-4

--- a/docs/releases/0_6_1.md
+++ b/docs/releases/0_6_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.1
-sidebar_position: 22
+sidebar_position: 23
 ---
 
 # 0.6.1 - 2022-3-7

--- a/docs/releases/0_6_2.md
+++ b/docs/releases/0_6_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.2
-sidebar_position: 21
+sidebar_position: 22
 ---
 
 # 0.6.2 - 2022-3-16

--- a/docs/releases/0_7_1.md
+++ b/docs/releases/0_7_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.7.1
-sidebar_position: 20
+sidebar_position: 21
 ---
 
 # 0.7.1 - 2022-4-19

--- a/docs/releases/0_8_1.md
+++ b/docs/releases/0_8_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.1
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # 0.8.1 - 2022-4-29

--- a/docs/releases/0_8_2.md
+++ b/docs/releases/0_8_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.2
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # 0.8.2 - 2022-5-19

--- a/docs/releases/0_9_0.md
+++ b/docs/releases/0_9_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.9.0
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # 0.9.0 - 2022-6-3


### PR DESCRIPTION
Release notes are needed for the most recent OpenLineage release, 0.23.0.

This adds the notes to the releases directory and bumps the position numbers of the previous releases.