### PR TITLE
fix custom CSS to display docs elements properly

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,6 +12,10 @@
 
 /* You can override the default Infima variables here. */
 :root {
+  --ifm-h1-font-size: 3rem;
+    --ifm-h2-font-size: 3rem;
+    --ifm-h3-font-size: 1.5rem;
+    --ifm-h4-font-size: 1.25rem;
   --ifm-color-primary: #b6420b;
   --ifm-color-primary-dark: #7f2e08;
   --ifm-color-primary-darker: #6d2807;
@@ -426,6 +430,33 @@ code .token-line {
   font-weight: bold;
 }
 
+.theme-doc-markdown ol {
+  list-style-type: inherit;
+  margin: 0 0 var(--ifm-list-margin);
+  padding-left: var(--ifm-list-left-padding);
+}
+
+.theme-doc-markdown ul {
+  list-style-type: inherit;
+  margin: 0 0 var(--ifm-list-margin);
+  padding-left: var(--ifm-list-left-padding);
+}
+
+.theme-doc-markdown h1 {
+  font-size: var(--ifm-h1-font-size);
+}
+
+.theme-doc-markdown h2 {
+  font-size: var(--ifm-h2-font-size);
+}
+
+.theme-doc-markdown h3 {
+  font-size: var(--ifm-h3-font-size);
+}
+
+.theme-doc-markdown h4 {
+  font-size: var(--ifm-h4-font-size);
+}
 code {
   background-color: #dedede;
   padding: 0.25rem 0.5rem;


### PR DESCRIPTION
This fixes some things - lists and headers - that were broken in Gatsby migration. 

Before:
<img width="1509" alt="Screenshot 2023-04-21 at 18 18 52" src="https://user-images.githubusercontent.com/6503007/233686046-7a277027-b68b-4ed5-8a34-4051a9b226cb.png">

After:
<img width="1509" alt="Screenshot 2023-04-21 at 18 18 59" src="https://user-images.githubusercontent.com/6503007/233686067-b58e5a1f-7191-4e64-a95b-01648fdf7cf5.png">
