### PR TITLE
edit NYC meetup post

### DIFF
--- a/blog/nyc-meetup/index.mdx
+++ b/blog/nyc-meetup/index.mdx
@@ -19,8 +19,10 @@ your ideas and vision for OpenLineage!
 
 Food will be provided, and the meetup is open to all. Don't miss this opportunity 
 to influence the direction of this important new standard! We hope to see you 
-there. Please [sign up](https://www.meetup.com/data-lineage-meetup/events/292897496) 
-to let us know you're coming.
+there. 
+
+**Please [sign up](https://www.meetup.com/data-lineage-meetup/events/292897496) 
+to let us know you're coming.**
 
 ### Time, Place & Format
 


### PR DESCRIPTION
The organization and formatting of this post don't draw attention to the sign-up link.

This reorganizes and formats the relevant line.