### PR TITLE
add 0.24.0 release notes and update all position numbers

### DIFF
--- a/docs/releases/0_10_0.md
+++ b/docs/releases/0_10_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.10.0
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # 0.10.0 - 2022-6-24

--- a/docs/releases/0_11_0.md
+++ b/docs/releases/0_11_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.11.0
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # 0.11.0 - 2022-7-7

--- a/docs/releases/0_12_0.md
+++ b/docs/releases/0_12_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.12.0
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # 0.12.0 - 2022-8-1

--- a/docs/releases/0_13_0.md
+++ b/docs/releases/0_13_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.0
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # 0.13.0 - 2022-8-22

--- a/docs/releases/0_13_1.md
+++ b/docs/releases/0_13_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.1
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # 0.13.1 - 2022-8-25

--- a/docs/releases/0_14_0.md
+++ b/docs/releases/0_14_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.0
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # 0.14.0 - 2022-9-6

--- a/docs/releases/0_14_1.md
+++ b/docs/releases/0_14_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.1
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # 0.14.1 - 2022-9-7

--- a/docs/releases/0_15_1.md
+++ b/docs/releases/0_15_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.15.1
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # 0.15.1 - 2022-10-5

--- a/docs/releases/0_16_1.md
+++ b/docs/releases/0_16_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.16.1
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # 0.16.1 - 2022-11-3

--- a/docs/releases/0_17_0.md
+++ b/docs/releases/0_17_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.17.0
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # 0.17.0 - 2022-11-16

--- a/docs/releases/0_18_0.md
+++ b/docs/releases/0_18_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.18.0
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # 0.18.0 - 2022-12-8

--- a/docs/releases/0_19_2.md
+++ b/docs/releases/0_19_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.19.2
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # 0.19.2 - 2023-1-4

--- a/docs/releases/0_1_0.md
+++ b/docs/releases/0_1_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.1.0
-sidebar_position: 34
+sidebar_position: 35
 ---
 
 # 0.1.0 - 2021-8-13

--- a/docs/releases/0_20_4.md
+++ b/docs/releases/0_20_4.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.4
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # 0.20.4 - 2023-2-7

--- a/docs/releases/0_20_6.md
+++ b/docs/releases/0_20_6.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.6
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # 0.20.6 - 2023-2-10

--- a/docs/releases/0_21_1.md
+++ b/docs/releases/0_21_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.21.1
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # 0.21.1 - 2023-3-2

--- a/docs/releases/0_22_0.md
+++ b/docs/releases/0_22_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.22.0
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 0.22.0 - 2023-4-3

--- a/docs/releases/0_23_0.md
+++ b/docs/releases/0_23_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.23.0
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # 0.23.0 - 2023-4-20

--- a/docs/releases/0_24_0.md
+++ b/docs/releases/0_24_0.md
@@ -1,0 +1,22 @@
+---
+title: 0.24.0
+sidebar_position: 1
+---
+
+# 0.24.0 - 2023-5-3
+
+### Added
+* **Support custom transport types** [`#1795`](https://github.com/OpenLineage/OpenLineage/pull/1795) [@nataliezeller1](https://github.com/nataliezeller1)   
+    *Adds a new interface, `TransportBuilder`, for creating custom transport types without having to modify core components of OpenLineage.*
+* **Airflow: dbt Cloud integration** [`#1418`](https://github.com/OpenLineage/OpenLineage/pull/1418) [@howardyoo](https://github.com/howardyoo)   
+    *Adds a new OpenLineage extractor for dbt Cloud that uses the dbt Cloud hook provided by Airflow to communicate with dbt Cloud via its API.*
+* **Spark: support dataset name modification using regex** [`#1796`](https://github.com/OpenLineage/OpenLineage/pull/1796) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *It is a common scenario to write Spark output datasets with a location path ending with `/year=2023/month=04`. The Spark parameter `spark.openlineage.dataset.removePath.pattern` introduced here allows for removing certain elements from a path with a regex pattern.*
+
+### Fixed
+* **Spark: catch exception when trying to obtain details of non-existing table.** [`#1798`](https://github.com/OpenLineage/OpenLineage/pull/1798) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *This mostly happens when getting table details on START event while the table is still not created.*
+* **Spark: LogicalPlanSerializer** [`#1792`](https://github.com/OpenLineage/OpenLineage/pull/1792) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Changes `LogicalPlanSerializer` to make use of non-shaded Jackson classes in order to serialize `LogicalPlans`. Note: class names are no longer serialized.* 
+* **Flink: fix Flink CI** [`#1801`](https://github.com/OpenLineage/OpenLineage/pull/1801) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)    
+    *Specifies an older image version that succeeds on CI in order to fix the Flink integration.*

--- a/docs/releases/0_2_0.md
+++ b/docs/releases/0_2_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.0
-sidebar_position: 33
+sidebar_position: 34
 ---
 
 # 0.2.0 - 2021-8-23

--- a/docs/releases/0_2_1.md
+++ b/docs/releases/0_2_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.1
-sidebar_position: 32
+sidebar_position: 33
 ---
 
 # 0.2.1 - 2021-8-27

--- a/docs/releases/0_2_2.md
+++ b/docs/releases/0_2_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.2
-sidebar_position: 31
+sidebar_position: 32
 ---
 
 # 0.2.2 - 2021-9-8

--- a/docs/releases/0_2_3.md
+++ b/docs/releases/0_2_3.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.3
-sidebar_position: 30
+sidebar_position: 31
 ---
 
 # 0.2.3 - 2021-10-7

--- a/docs/releases/0_3_0.md
+++ b/docs/releases/0_3_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.0
-sidebar_position: 29
+sidebar_position: 30
 ---
 
 # 0.3.0 - 2021-12-3

--- a/docs/releases/0_3_1.md
+++ b/docs/releases/0_3_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.1
-sidebar_position: 28
+sidebar_position: 29
 ---
 
 # 0.3.1 - 2021-12-3

--- a/docs/releases/0_4_0.md
+++ b/docs/releases/0_4_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.4.0
-sidebar_position: 27
+sidebar_position: 28
 ---
 
 # 0.4.0 - 2021-12-13

--- a/docs/releases/0_5_1.md
+++ b/docs/releases/0_5_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.1
-sidebar_position: 26
+sidebar_position: 27
 ---
 
 # 0.5.1 - 2022-1-18

--- a/docs/releases/0_5_2.md
+++ b/docs/releases/0_5_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.2
-sidebar_position: 25
+sidebar_position: 26
 ---
 
 # 0.5.2 - 2022-2-10

--- a/docs/releases/0_6_0.md
+++ b/docs/releases/0_6_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.0
-sidebar_position: 24
+sidebar_position: 25
 ---
 
 # 0.6.0 - 2022-3-4

--- a/docs/releases/0_6_1.md
+++ b/docs/releases/0_6_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.1
-sidebar_position: 23
+sidebar_position: 24
 ---
 
 # 0.6.1 - 2022-3-7

--- a/docs/releases/0_6_2.md
+++ b/docs/releases/0_6_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.2
-sidebar_position: 22
+sidebar_position: 23
 ---
 
 # 0.6.2 - 2022-3-16

--- a/docs/releases/0_7_1.md
+++ b/docs/releases/0_7_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.7.1
-sidebar_position: 21
+sidebar_position: 22
 ---
 
 # 0.7.1 - 2022-4-19

--- a/docs/releases/0_8_1.md
+++ b/docs/releases/0_8_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.1
-sidebar_position: 20
+sidebar_position: 21
 ---
 
 # 0.8.1 - 2022-4-29

--- a/docs/releases/0_8_2.md
+++ b/docs/releases/0_8_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.2
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # 0.8.2 - 2022-5-19

--- a/docs/releases/0_9_0.md
+++ b/docs/releases/0_9_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.9.0
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # 0.9.0 - 2022-6-3


### PR DESCRIPTION
Release notes are needed for the most recent release, 0.24.0.

This adds the notes and updates all position numbers.