### PR TITLE
add community page to docs site

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -15,61 +15,60 @@ import Footer from '@site/src/components/footer';
     </h2>
 </div>
 
-<div class="text-center pt-8"><h2>Meetups</h2></div>
+<div className="text-center pt-8"><h2>Meetups</h2></div>
 <p>In-person meetups are an exciting, new aspect of the OpenLineage community, and more events are planned. Get in touch with the <a href="mailto:michael.robinson@astronomer.io">community team</a> if you are interested in hosting a meetup in your area.</p>
+<div className="container"><div className="row"><div className="col">
 
-| <div class="text-xl pl-5 pr-5">DATE</div> | <div class="text-xl pl-5 pr-5">CITY</div> | <div class="text-xl pl-5 pr-5">EVENT</div> |
+| <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
-| <div class="text-xl p-5">April 26, 2023</div> | <div class="text-xl pl-5">New York, NY</div> | <div class="text-xl pl-5">OpenLineage Meetup at Astronomer HQ</div> |
-| <div class="text-xl p-5">March 30, 2023</div> | <div class="text-xl pl-5">Austin, TX</div> | <div class="text-xl pl-5">OpenLineage Meetup at Data Council Austin</div> |
-| <div class="text-xl p-5">March 9, 2023</div> | <div class="text-xl pl-5 pr-5">Providence, RI</div> | <div class="text-xl pl-5 pr-5">Inaugural Data Lineage Meetup in downtown PVD</div> |
+| <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
+| <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |
 
+</div></div></div>
 
-
-<div class="text-center pt-8"><h2>TSC Meetings</h2></div>
+<div className="text-center pt-8"><h2>TSC Meetings</h2></div>
 <div className="container">
-<div className="row">
-<div className="col">
-<p className="text-2xl">The OpenLineage Technical Steering Committee meets monthly on the second Thursday from 10:00am to 11:00am US Pacific.</p>
-<p>TSC meetings are open to all who RSVP. During them, we review recent releases, hear from contributors of major new developments, and feature guest speakers on various topics of interest to the community.</p>
-<p>These meetings take place on Zoom. Meetings are recorded and published on the <a href="https://www.youtube.com/@openlineageproject6897/videos">OpenLineage YouTube Channel</a>. Notes for the meeting are published in a page on the <a href="https://wiki.lfaidata.foundation/display/OpenLineage/Monthly+TSC+meeting">OpenLineage Wiki</a>.</p>
-<p>To RSVP, select a meeting from the list or <a href="https://www.addevent.com/calendar/pP575215">click this link</a> (or the Subscribe link at the top of the list) to be invited to the complete series. Once you RSVP, you will receive a calendar invite with the video meeting link and password.</p> 
-</div>
-<div className="col col--4">
-<AddEvent />
-</div>
-</div>
+    <div className="row">
+        <div className="col">
+            <p className="text-2xl">The OpenLineage Technical Steering Committee meets monthly on the second Thursday from 10:00am to 11:00am US Pacific.</p>
+            <p>TSC meetings are open to all who RSVP. During them, we review recent releases, hear from contributors of major new developments, and feature guest speakers on various topics of interest to the community.</p>
+            <p>These meetings take place on Zoom. Meetings are recorded and published on the <a href="https://www.youtube.com/@openlineageproject6897/videos">OpenLineage YouTube Channel</a>. Notes for the meeting are published in a page on the <a href="https://wiki.lfaidata.foundation/display/OpenLineage/Monthly+TSC+meeting">OpenLineage Wiki</a>.</p>
+            <p>To RSVP, select a meeting from the list or <a href="https://www.addevent.com/calendar/pP575215">click this link</a> (or the Subscribe link at the top of the list) to be invited to the complete series. Once you RSVP, you will receive a calendar invite with the video meeting link and password.</p> 
+        </div>
+        <div className="col col--4">
+            <AddEvent />
+        </div>
+    </div>
 </div>
 
-<div class="text-center pt-8"><h2>Wiki</h2></div>
+<div className="text-center pt-8"><h2>Wiki</h2></div>
 <div className="container text-center">
-<div className="row">
-<p>Visit the <a href="https://bit.ly/OLwiki">OpenLineage Wiki</a> for documentation of the monthly TSC meetings, including meeting dates, attendees, notes, agendas and recordings.</p>
-</div>
+    <div className="row">
+        <p>Visit the <a href="https://bit.ly/OLwiki">OpenLineage Wiki</a> for documentation of the monthly TSC meetings, including meeting dates, attendees, notes, agendas and recordings.</p>
+    </div>
 </div>
 
-<div class="text-center pt-8"><h2>Slack</h2></div>
+<div className="text-center pt-8"><h2>Slack</h2></div>
 <div className="container text-center">
-<div className="row">
-<p>Join us on the <a href="https://bit.ly/OLslack">OpenLineage Slack</a> to stay up-to-date on upcoming events, releases and discussions. The Slack community is a great place to ask questions and get to know OpenLineage contributors and users around the world.</p>
-</div>
+    <div className="row">
+        <p>Join us on the <a href="https://bit.ly/OLslack">OpenLineage Slack</a> to stay up-to-date on upcoming events, releases and discussions. The Slack community is a great place to ask questions and get to know OpenLineage contributors and users around the world.</p>
+    </div>
 </div>
 
-<div class="text-center pt-8"><h2>GitHub</h2></div>
+<div className="text-center pt-8"><h2>GitHub</h2></div>
 <div className="container text-center">
-<div className="row">
-<p>Visit the <a href="https://github.com/OpenLineage">GitHub organization</a> for the main codebase and docs, workshop and other repositories. Contributions are welcome. Read the <a href="https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md">new contributor guide</a> for instructions on getting started.</p>
-</div>
+    <div className="row">
+        <p>Visit the <a href="https://github.com/OpenLineage">GitHub organization</a> for the main codebase and docs, workshop and other repositories. Contributions are welcome. Read the <a href="https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md">new contributor guide</a> for instructions on getting started.</p>
+    </div>
 </div>
 
-<div class="text-center pt-8">&nbsp;</div>
+<div className="text-center pt-8">&nbsp;</div>
 <div className="container text-center">
-<div className="row">
-<p>&nbsp;</p>
+    <div className="row">
+        <p>&nbsp;</p>
+    </div>
 </div>
-</div>
-
-
 
 </div>
 

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -1,0 +1,76 @@
+---
+title: Community
+template: basepage
+hide_table_of_contents: true
+description: Data lineage is the foundation for a new generation of powerful, context-aware data tools and best practices. OpenLineage enables consistent collection of lineage metadata, creating a deeper understanding of how data is produced and used.
+---
+import AddEvent from '@site/src/components/addevent';
+import Footer from '@site/src/components/footer';
+
+<div id="post-content" className="CommunityPage boxed">
+
+<div className="title px-4 py-12 text-center lg:py-14 lg:px-0">
+    <h2 className="text-5xl text-color-1">
+        Community Resources
+    </h2>
+</div>
+
+<div class="text-center pt-8"><h2>Meetups</h2></div>
+<p>In-person meetups are an exciting, new aspect of the OpenLineage community, and more events are planned. Get in touch with the <a href="mailto:michael.robinson@astronomer.io">community team</a> if you are interested in hosting a meetup in your area.</p>
+
+| <div class="text-xl pl-5 pr-5">DATE</div> | <div class="text-xl pl-5 pr-5">CITY</div> | <div class="text-xl pl-5 pr-5">EVENT</div> |
+| ----------- | ----------- | ----------- |
+| <div class="text-xl p-5">April 26, 2023</div> | <div class="text-xl pl-5">New York, NY</div> | <div class="text-xl pl-5">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-5">March 30, 2023</div> | <div class="text-xl pl-5">Austin, TX</div> | <div class="text-xl pl-5">OpenLineage Meetup at Data Council Austin</div> |
+| <div class="text-xl p-5">March 9, 2023</div> | <div class="text-xl pl-5 pr-5">Providence, RI</div> | <div class="text-xl pl-5 pr-5">Inaugural Data Lineage Meetup in downtown PVD</div> |
+
+
+
+<div class="text-center pt-8"><h2>TSC Meetings</h2></div>
+<div className="container">
+<div className="row">
+<div className="col">
+<p className="text-2xl">The OpenLineage Technical Steering Committee meets monthly on the second Thursday from 10:00am to 11:00am US Pacific.</p>
+<p>TSC meetings are open to all who RSVP. During them, we review recent releases, hear from contributors of major new developments, and feature guest speakers on various topics of interest to the community.</p>
+<p>These meetings take place on Zoom. Meetings are recorded and published on the <a href="https://www.youtube.com/@openlineageproject6897/videos">OpenLineage YouTube Channel</a>. Notes for the meeting are published in a page on the <a href="https://wiki.lfaidata.foundation/display/OpenLineage/Monthly+TSC+meeting">OpenLineage Wiki</a>.</p>
+<p>To RSVP, select a meeting from the list or <a href="https://www.addevent.com/calendar/pP575215">click this link</a> (or the Subscribe link at the top of the list) to be invited to the complete series. Once you RSVP, you will receive a calendar invite with the video meeting link and password.</p> 
+</div>
+<div className="col col--4">
+<AddEvent />
+</div>
+</div>
+</div>
+
+<div class="text-center pt-8"><h2>Wiki</h2></div>
+<div className="container text-center">
+<div className="row">
+<p>Visit the <a href="https://bit.ly/OLwiki">OpenLineage Wiki</a> for documentation of the monthly TSC meetings, including meeting dates, attendees, notes, agendas and recordings.</p>
+</div>
+</div>
+
+<div class="text-center pt-8"><h2>Slack</h2></div>
+<div className="container text-center">
+<div className="row">
+<p>Join us on the <a href="https://bit.ly/OLslack">OpenLineage Slack</a> to stay up-to-date on upcoming events, releases and discussions. The Slack community is a great place to ask questions and get to know OpenLineage contributors and users around the world.</p>
+</div>
+</div>
+
+<div class="text-center pt-8"><h2>GitHub</h2></div>
+<div className="container text-center">
+<div className="row">
+<p>Visit the <a href="https://github.com/OpenLineage">GitHub organization</a> for the main codebase and docs, workshop and other repositories. Contributions are welcome. Read the <a href="https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md">new contributor guide</a> for instructions on getting started.</p>
+</div>
+</div>
+
+<div class="text-center pt-8">&nbsp;</div>
+<div className="container text-center">
+<div className="row">
+<p>&nbsp;</p>
+</div>
+</div>
+
+
+
+</div>
+
+<Footer />


### PR DESCRIPTION
The website/docs site is missing a dedicated page containing community resources, an expected and useful feature of a typical project website.

This adds a community page to the website with appropriate links and descriptions (meetings, meetups, etc.).

![screencapture-localhost-3000-community-2023-05-09-09_43_08](https://github.com/OpenLineage/docs/assets/68482867/535f236b-aaef-4d07-a340-0062e4738c74)