### PR TITLE
add LinkedIn link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,7 @@ const links = [
 const linksSocial = [
   { href: 'https://fosstodon.org/@openlineage', label: 'Mastodon', rel: 'me' },
   { href: 'https://twitter.com/OpenLineage', label: 'Twitter' },
+  { href: 'https://www.linkedin.com/groups/13927795/', label: 'LinkedIn'},
   { href: 'http://bit.ly/OpenLineageSlack', label: 'Slack' },
   { href: 'https://github.com/OpenLineage/OpenLineage', label: 'GitHub' }
 ]

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -21,7 +21,7 @@ import Footer from '@site/src/components/footer';
 
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
-| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">[OpenLineage Meetup at Astronomer HQ](https://openlineage.io/blog/sf-meetup)</div> |
 | <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
 | <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -21,6 +21,7 @@ import Footer from '@site/src/components/footer';
 
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
+| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
 | <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |


### PR DESCRIPTION
This adds a link to our LinkedIn group to the footer where we have links to twitter, Slack, etc.

Also included: the June 27 meetup is added to the community page.