### PR TITLE
add survey announcement banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,6 +140,13 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },  
+      announcementBar: {
+        id: 'survey_alert',
+        content: 'Help chart the course of OpenLineage! The 2023 Ecosystem Survey is live and accepting responses. <a href="https://forms.gle/cPk3skNgnB4iab9H6">Submit yours today</a>.',
+        backgroundColor: '#FF6700',
+        textColor: '#091E42',
+        isCloseable: false,
+      }
     }),
 
   scripts:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,7 +143,7 @@ const config = {
       announcementBar: {
         id: 'survey_alert',
         content: 'Help chart the course of OpenLineage! The 2023 Ecosystem Survey is live and accepting responses. <a href="https://forms.gle/cPk3skNgnB4iab9H6">Submit yours today</a>.',
-        backgroundColor: '#FF6700',
+        backgroundColor: '#f26522',
         textColor: '#091E42',
         isCloseable: false,
       }


### PR DESCRIPTION
This adds an announcement banner with a link to the survey. It appears on all pages (disregard the commit message) but is not sticky.

![Screenshot 2023-05-19 at 10 18 47](https://github.com/OpenLineage/docs/assets/68482867/38b36717-0a92-4e97-a78f-491d820bfb6a)
