### PR TITLE
add 0.27.1 release notes and bump sidebar positions

### DIFF
--- a/docs/releases/0_10_0.md
+++ b/docs/releases/0_10_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.10.0
-sidebar_position: 20
+sidebar_position: 21
 ---
 
 # 0.10.0 - 2022-06-24

--- a/docs/releases/0_11_0.md
+++ b/docs/releases/0_11_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.11.0
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # 0.11.0 - 2022-07-07

--- a/docs/releases/0_12_0.md
+++ b/docs/releases/0_12_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.12.0
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # 0.12.0 - 2022-08-01

--- a/docs/releases/0_13_0.md
+++ b/docs/releases/0_13_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.0
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # 0.13.0 - 2022-08-22

--- a/docs/releases/0_13_1.md
+++ b/docs/releases/0_13_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.1
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # 0.13.1 - 2022-08-25

--- a/docs/releases/0_14_0.md
+++ b/docs/releases/0_14_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.0
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # 0.14.0 - 2022-09-06

--- a/docs/releases/0_14_1.md
+++ b/docs/releases/0_14_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.1
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # 0.14.1 - 2022-09-07

--- a/docs/releases/0_15_1.md
+++ b/docs/releases/0_15_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.15.1
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # 0.15.1 - 2022-10-05

--- a/docs/releases/0_16_1.md
+++ b/docs/releases/0_16_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.16.1
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # 0.16.1 - 2022-11-03

--- a/docs/releases/0_17_0.md
+++ b/docs/releases/0_17_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.17.0
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # 0.17.0 - 2022-11-16

--- a/docs/releases/0_18_0.md
+++ b/docs/releases/0_18_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.18.0
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # 0.18.0 - 2022-12-08

--- a/docs/releases/0_19_2.md
+++ b/docs/releases/0_19_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.19.2
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # 0.19.2 - 2023-01-04

--- a/docs/releases/0_1_0.md
+++ b/docs/releases/0_1_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.1.0
-sidebar_position: 37
+sidebar_position: 38
 ---
 
 # 0.1.0 - 2021-08-13

--- a/docs/releases/0_20_4.md
+++ b/docs/releases/0_20_4.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.4
-sidebar_position: 8
+sidebar_position: 09
 ---
 
 # 0.20.4 - 2023-02-07

--- a/docs/releases/0_20_6.md
+++ b/docs/releases/0_20_6.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.6
-sidebar_position: 7
+sidebar_position: 08
 ---
 
 # 0.20.6 - 2023-02-10

--- a/docs/releases/0_21_1.md
+++ b/docs/releases/0_21_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.21.1
-sidebar_position: 6
+sidebar_position: 07
 ---
 
 # 0.21.1 - 2023-03-02

--- a/docs/releases/0_22_0.md
+++ b/docs/releases/0_22_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.22.0
-sidebar_position: 5
+sidebar_position: 06
 ---
 
 # 0.22.0 - 2023-04-03

--- a/docs/releases/0_23_0.md
+++ b/docs/releases/0_23_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.23.0
-sidebar_position: 4
+sidebar_position: 05
 ---
 
 # 0.23.0 - 2023-04-20

--- a/docs/releases/0_24_0.md
+++ b/docs/releases/0_24_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.24.0
-sidebar_position: 3
+sidebar_position: 04
 ---
 
 # 0.24.0 - 2023-05-03

--- a/docs/releases/0_25_0.md
+++ b/docs/releases/0_25_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.25.0
-sidebar_position: 2
+sidebar_position: 03
 ---
 
 # 0.25.0 - 2023-05-15

--- a/docs/releases/0_26_0.md
+++ b/docs/releases/0_26_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.26.0
-sidebar_position: 1
+sidebar_position: 02
 ---
 
 # 0.26.0 - 2023-05-18

--- a/docs/releases/0_27_1.md
+++ b/docs/releases/0_27_1.md
@@ -1,0 +1,16 @@
+---
+title: 0.27.1
+sidebar_position: 01
+---
+
+# 0.27.1 - 2023-06-05
+
+### Added
+* **Python client: add emission filtering mechanism and exact, regex filters** [`#1878`](https://github.com/OpenLineage/OpenLineage/pull/1878) [@mobuchowski](https://github.com/mobuchowski)  
+    *Adds configurable job-name filtering to the Python client. Filters can be exact-match- or regex-based. Events will not be sent in the case of matches.*
+
+### Fixed
+* **Spark: fix column lineage for aggregate queries on databricks** [`#1867`](https://github.com/OpenLineage/OpenLineage/pull/1867) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Aggregate queries on databricks did not return column lineage.*
+* **Airflow: fix unquoted `[` and `]` in Snowflake URIs** [`#1883`](https://github.com/OpenLineage/OpenLineage/pull/1883) [@JDarDagran](https://github.com/JDarDagran)  
+    *Snowflake connections containing one of `[` or `]` were causing `urllib.parse.urlparse` to fail.*

--- a/docs/releases/0_2_0.md
+++ b/docs/releases/0_2_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.0
-sidebar_position: 36
+sidebar_position: 37
 ---
 
 # 0.2.0 - 2021-08-23

--- a/docs/releases/0_2_1.md
+++ b/docs/releases/0_2_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.1
-sidebar_position: 35
+sidebar_position: 36
 ---
 
 # 0.2.1 - 2021-08-27

--- a/docs/releases/0_2_2.md
+++ b/docs/releases/0_2_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.2
-sidebar_position: 34
+sidebar_position: 35
 ---
 
 # 0.2.2 - 2021-09-08

--- a/docs/releases/0_2_3.md
+++ b/docs/releases/0_2_3.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.3
-sidebar_position: 33
+sidebar_position: 34
 ---
 
 # 0.2.3 - 2021-10-07

--- a/docs/releases/0_3_0.md
+++ b/docs/releases/0_3_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.0
-sidebar_position: 32
+sidebar_position: 33
 ---
 
 # 0.3.0 - 2021-12-03

--- a/docs/releases/0_3_1.md
+++ b/docs/releases/0_3_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.1
-sidebar_position: 31
+sidebar_position: 32
 ---
 
 # 0.3.1 - 2021-12-03

--- a/docs/releases/0_4_0.md
+++ b/docs/releases/0_4_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.4.0
-sidebar_position: 30
+sidebar_position: 31
 ---
 
 # 0.4.0 - 2021-12-13

--- a/docs/releases/0_5_1.md
+++ b/docs/releases/0_5_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.1
-sidebar_position: 29
+sidebar_position: 30
 ---
 
 # 0.5.1 - 2022-01-18

--- a/docs/releases/0_5_2.md
+++ b/docs/releases/0_5_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.2
-sidebar_position: 28
+sidebar_position: 29
 ---
 
 # 0.5.2 - 2022-02-10

--- a/docs/releases/0_6_0.md
+++ b/docs/releases/0_6_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.0
-sidebar_position: 27
+sidebar_position: 28
 ---
 
 # 0.6.0 - 2022-03-04

--- a/docs/releases/0_6_1.md
+++ b/docs/releases/0_6_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.1
-sidebar_position: 26
+sidebar_position: 27
 ---
 
 # 0.6.1 - 2022-03-07

--- a/docs/releases/0_6_2.md
+++ b/docs/releases/0_6_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.2
-sidebar_position: 25
+sidebar_position: 26
 ---
 
 # 0.6.2 - 2022-03-16

--- a/docs/releases/0_7_1.md
+++ b/docs/releases/0_7_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.7.1
-sidebar_position: 24
+sidebar_position: 25
 ---
 
 # 0.7.1 - 2022-04-19

--- a/docs/releases/0_8_1.md
+++ b/docs/releases/0_8_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.1
-sidebar_position: 23
+sidebar_position: 24
 ---
 
 # 0.8.1 - 2022-04-29

--- a/docs/releases/0_8_2.md
+++ b/docs/releases/0_8_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.2
-sidebar_position: 22
+sidebar_position: 23
 ---
 
 # 0.8.2 - 2022-05-19

--- a/docs/releases/0_9_0.md
+++ b/docs/releases/0_9_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.9.0
-sidebar_position: 21
+sidebar_position: 22
 ---
 
 # 0.9.0 - 2022-06-03


### PR DESCRIPTION
This adds the 0.27.1 releases notes and bumps all other position numbers.