### PR TITLE
fix Slack link on home

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -188,7 +188,7 @@ const Participate = () => {
 
               <Button
                   title="Slack"
-                  to='http://bit.ly/OpenLineageSlack'
+                  to='https://bit.ly/OLslack'
                   type="extbutton"
                   iconRight={<Slack />}
                   className="mx-5"


### PR DESCRIPTION
The link to Slack on home isn't correct. This fixes the link.