### PR TITLE
Fix naming.md - paying attention to namespace and name

### DIFF
--- a/docs/spec/naming.md
+++ b/docs/spec/naming.md
@@ -12,18 +12,18 @@ Jobs and Datasets have their own namespaces, job namespaces being derived from s
 
 A dataset, or `table`, is organized according to a producer, namespace, database and (optionally) schema.
 
-| Producer | Formula | Example URI |
-| -------- | ------- | ----------- |
-| Postgres | producer + host + port + database + table | postgres://db.foo.com:6543/metrics.sales.orders |
-| MySQL | producer + host + port + database + table | mysql://db.foo.com:6543/metrics.orders | 
-| S3 | producer + bucket + path | s3://sales-metrics/orders.csv |
-| GCS | producer + bucket + path | gcs://sales-metrics/orders.csv |
-| HDFS | producer + host + port + path | hdfs://stg.foo.com:3000/salesorders.csv |
-| BigQuery | producer + project + dataset + table | bigquery:metrics.sales.orders |
-| Redshift | producer + host + port + database + schema + table | redshift://examplecluster.XXXXXXXXXXXX.us-west-2.redshift.amazonaws.com:5439/metrics.sales.orders |
-| Athena | producer + host + catalog + database + table | awsathena://athena.us-west-2.amazonaws.com/metrics.sales.orders |
-| Azure Synapse | producer + host + port + database + schema + table | sqlserver://XXXXXXXXXXXX.sql.azuresynapse.net:1433;database=SQLPool1/sales.orders |
-| Azure Cosmos DB | producer + host + database + 'colls' + table | azurecosmos://XXXXXXXXXXXX.documents.azure.com/dbs/metrics/colls/orders |
+| Producer | Namespace | Name | Example Namespace | Example Name |
+| -------- | --------- | ---- | ----------------- | ------------ |
+| Postgres | postgres + host + port | database + table | postgres://db.foo.com:6543 | metrics.sales.orders |
+| MySQL | mysql + host + port | database + table | mysql://db.foo.com:6543 | metrics.orders | 
+| S3 | s3 + bucket | path | s3://sales-metrics | orders.csv |
+| GCS | gcs + bucket | path | gcs://sales-metrics | orders.csv |
+| HDFS | hdfs + host + port | path | hdfs://stg.foo.com:3000 | salesorders.csv |
+| BigQuery | bigquery |  project + dataset + table | bigquery | metrics.sales.orders |
+| Redshift | redshift + host + port | database + schema + table | redshift://examplecluster.XXXXXXXXXXXX.us-west-2.redshift.amazonaws.com:5439 | metrics.sales.orders |
+| Athena | awsathena + host | catalog + database + table | awsathena://athena.us-west-2.amazonaws.com | metrics.sales.orders |
+| Azure Synapse | producer + host + port | database + schema + table | sqlserver://XXXXXXXXXXXX.sql.azuresynapse.net:1433 | SQLPool1/sales.orders |
+| Azure Cosmos DB | producer + host | database + 'colls' + table | azurecosmos://XXXXXXXXXXXX.documents.azure.com/dbs | metrics.colls.orders |
 
 ## Job Naming
 


### PR DESCRIPTION
Currently, naming convention doc fails to properly split namespace and name. This PR fixes that.