### PR TITLE
add recent talks

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -21,7 +21,7 @@ import Footer from '@site/src/components/footer';
 
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
-| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">[OpenLineage Meetup at Astronomer HQ](https://openlineage.io/blog/sf-meetup)</div> |
+| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
 | <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -20,6 +20,8 @@ These resources have been gathered to help new users learn about OpenLineage, or
 
 ## Conference Talks
 
+* [Cross-platform Data Lineage with OpenLineage](https://www.databricks.com/dataaisummit/session/cross-platform-data-lineage-openlineage/) - Julien Le Dem and Willy Lulciuc @ Data+AI Summit (2023)
+* [Column-level Lineage is Coming to the Rescue](https://youtu.be/xFVSZCCbZlY) - Paweł Leszczynski and Maciej Obuchowski @ Berlin Buzzwords (2023)
 * [Cross-platform Data Lineage with OpenLineage](https://www.youtube.com/watch?v=pLBVGIPuwEo) - Julien Le Dem @ Berlin Buzzwords (2022)
 * [Data Observability and Pipelines: OpenLineage and Marquez](https://mattturck.com/datakin/) - Matt Turck @ Data Driven NYC (2021)
 * [Data Lineage and Observability with Marquez and OpenLineage](https://bigdatatechwarsaw.eu/edition-2021/) - Julien Le Dem @ Big Data Technology Warsaw Summit (2021)


### PR DESCRIPTION
The list of talks on the Resources page is not current.

This adds recent talks to the list.