### PR TITLE
add newsletter signup landing page

### DIFF
--- a/src/pages/news-landing/index.mdx
+++ b/src/pages/news-landing/index.mdx
@@ -1,0 +1,20 @@
+---
+title: News Landing Page
+template: basepage
+hide_table_of_contents: true
+description: Data lineage is the foundation for a new generation of powerful, context-aware data tools and best practices. OpenLineage enables consistent collection of lineage metadata, creating a deeper understanding of how data is produced and used.
+---
+
+import Footer from '@site/src/components/footer';
+
+<div className="title px-4 py-12 text-center lg:py-14 lg:px-0">
+    <h2 className="text-5xl text-color-1">
+        Thank you!
+    </h2>
+</div>
+
+<p className="text-center pt-8">Thank you for signing up for our monthly newsletter. Issues are published around the last day of each month.</p>
+
+<p className="text-center pt-8">You can manage your subscription preferences <a href="https://openlineage.us14.list-manage.com/profile/?u=fe7ef7a8dbb32933f30a10466&id=18dcb85f3e&e=*|UNIQID|*">here</a>.</p>
+
+

--- a/src/pages/news-landing/index.mdx
+++ b/src/pages/news-landing/index.mdx
@@ -17,4 +17,18 @@ import Footer from '@site/src/components/footer';
 
 <p className="text-center pt-8">You can manage your subscription preferences <a href="https://openlineage.us14.list-manage.com/profile/?u=fe7ef7a8dbb32933f30a10466&id=18dcb85f3e&e=*|UNIQID|*">here</a>.</p>
 
+<div className="text-center pt-8">&nbsp;</div>
+<div className="container text-center">
+    <div className="row">
+        <p>&nbsp;</p>
+    </div>
+    <div className="row">
+        <p>&nbsp;</p>
+    </div>
+    <div className="row">
+        <p>&nbsp;</p>
+    </div>
+</div>
 
+
+<Footer />


### PR DESCRIPTION
The url of the Mailchimp newsletter's confirmation page is evidently not customizable. 

This adds a landing page to the site that Mailchimp will be configured to redirect subscribers to.