### PR TITLE
update community page with addevent change

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -21,7 +21,7 @@ import Footer from '@site/src/components/footer';
 
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
-| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">[OpenLineage Meetup at Astronomer HQ](https://openlineage.io/blog/sf-meetup)</div> |
+| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
 | <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |
@@ -35,7 +35,8 @@ import Footer from '@site/src/components/footer';
             <p className="text-2xl">The OpenLineage Technical Steering Committee meets monthly on the second Thursday from 10:00am to 11:00am US Pacific.</p>
             <p>TSC meetings are open to all who RSVP. During them, we review recent releases, hear from contributors of major new developments, and feature guest speakers on various topics of interest to the community.</p>
             <p>These meetings take place on Zoom. Meetings are recorded and published on the <a href="https://www.youtube.com/@openlineageproject6897/videos">OpenLineage YouTube Channel</a>. Notes for the meeting are published in a page on the <a href="https://wiki.lfaidata.foundation/display/OpenLineage/Monthly+TSC+meeting">OpenLineage Wiki</a>.</p>
-            <p>To RSVP, select a meeting from the list or <a href="https://www.addevent.com/calendar/pP575215">click this link</a> (or the Subscribe link at the top of the list) to be invited to the complete series. Once you RSVP, you will receive a calendar invite with the video meeting link and password.</p> 
+            <p>To RSVP, select a meeting from the list and click the RSVP button. You will receive a calendar invite with the video meeting link and password.</p>
+            <p>(Please note: We are migrating from recurring events to an editable events series, hence the duplicate events. Please disregard events without red RSVP buttons as we migrate over.)</p>
         </div>
         <div className="col col--4">
             <AddEvent />


### PR DESCRIPTION
We have had to create a new events series on AddEvent to permit changes to individual events. This change updates the language about meeting signup accordingly as we migrate.