### PR TITLE
add missing database creation steps to airflow quickstart

### DIFF
--- a/docs/guides/airflow-quickstart.md
+++ b/docs/guides/airflow-quickstart.md
@@ -46,7 +46,7 @@ Use the Astro CLI to create and run an Airflow project locally that will integra
 
     ```sh
     $ mkdir docker && cd docker
-    $ curl -O "https://raw.githubusercontent.com/vishnubob/wait-for-it/main/{entrypoint.sh,wait-for-it.sh}"
+    $ curl -O "https://raw.githubusercontent.com/MarquezProject/marquez/main/docker/{entrypoint.sh,wait-for-it.sh}"
     $ ..
     ```
 

--- a/docs/guides/airflow-quickstart.md
+++ b/docs/guides/airflow-quickstart.md
@@ -26,7 +26,7 @@ Before you begin, make sure you have installed:
 
 * [Docker 17.05](https://docs.docker.com/install)+
 * [Astro CLI](https://docs.astronomer.io/astro/cli/overview)
-* [Subversion](https://subversion.apache.org/)
+* [curl](https://curl.se/)
 
 > **Note:** We recommend that you have allocated at least **2 CPUs** and **8 GB** of memory to Docker.
 
@@ -42,10 +42,12 @@ Use the Astro CLI to create and run an Airflow project locally that will integra
     $ astro dev init
     ```
 
-2. Using Subversion, download some scripts required by Marquez services:
+2. Using curl, change into new directory `docker` and download some scripts required by Marquez services:
 
     ```sh
-    svn checkout https://github.com/MarquezProject/marquez/trunk/docker
+    $ mkdir docker && cd docker
+    $ curl -O "https://raw.githubusercontent.com/vishnubob/wait-for-it/main/{entrypoint.sh,wait-for-it.sh}"
+    $ ..
     ```
 
     After executing the above, your project directory should look like this:
@@ -116,8 +118,6 @@ services:
       - POSTGRES_USER=example
       - POSTGRES_PASSWORD=example
       - POSTGRES_DB=example
-    sysctls:
-      - net.ipv4.tcp_keepalive_time=200
   
   api:
     image: marquezproject/marquez:latest
@@ -324,8 +324,8 @@ query2 = PostgresOperator(
     postgres_conn_id='example_db',
     sql='''
     INSERT INTO sums (value)
--       SELECT SUM(c.value) FROM counts AS c;
-+       SELECT SUM(c.value_1_to_10) FROM counts AS c;
+-       SELECT SUM(value) FROM counts;
++       SELECT SUM(value_1_to_10) FROM counts;
     '''
 )
 ```

--- a/docs/guides/airflow-quickstart.md
+++ b/docs/guides/airflow-quickstart.md
@@ -15,11 +15,10 @@ In this example, we'll walk you through how to enable Airflow DAGs to send linea
 
 1. [Step 1: Configure Your Astro Project](#configure-your-astro-project)
 2. [Step 2: Add Marquez Services Using Docker Compose](#add-marquez-services-using-docker-compose)
-3. [Step 3: Add a Script for Initializing the Database in the Docker Container](#add-a-script-for-initializing-the-database-in-the-docker-container)
-4. [Step 4: Start Airflow with Marquez](#start-airflow-with-marquez)
-5. [Step 5: Write Airflow DAGs](#write-airflow-dags)
-6. [Step 6: View Collected Metadata](#view-collected-metadata)
-7. [Step 7: Troubleshoot a Failing DAG with Marquez](#troubleshoot-a-failing-dag-with-marquez)
+3. [Step 3: Start Airflow with Marquez](#start-airflow-with-marquez)
+4. [Step 4: Write Airflow DAGs](#write-airflow-dags)
+5. [Step 5: View Collected Metadata](#view-collected-metadata)
+6. [Step 6: Troubleshoot a Failing DAG with Marquez](#troubleshoot-a-failing-dag-with-marquez)
 
 ## Prerequisites
 
@@ -104,15 +103,9 @@ services:
     ports:
       - "6543:6543"
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - MARQUEZ_DB=marquez
-      - MARQUEZ_USER=marquez
-      - MARQUEZ_PASSWORD=marquez
-      - ALLOW_EMPTY_PASSWORD=yes
-    volumes:
-      - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-    command: ["postgres", "-c", "log_statement=all"]
+      - POSTGRES_USER=marquez
+      - POSTGRES_PASSWORD=marquez
+      - POSTGRES_DB=marquez
 
   example-db:
     image: postgres:12.1
@@ -120,15 +113,9 @@ services:
     ports:
       - "7654:5432"
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - EXAMPLE_USER=example
-      - EXAMPLE_PASSWORD=example
-      - EXAMPLE_DB=example
-      - ALLOW_EMPTY_PASSWORD=yes
-    volumes:
-      - ./docker/init-example-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-    command: ["postgres", "-c", "log_statement=all"]
+      - POSTGRES_USER=example
+      - POSTGRES_PASSWORD=example
+      - POSTGRES_DB=example
     sysctls:
       - net.ipv4.tcp_keepalive_time=200
   
@@ -157,34 +144,6 @@ services:
 
 The above adds the Marquez API, database and Web UI, along with an additional Postgres database for the DAGs used in this example, to Astro's Docker container and configures them to use the scripts in the `docker` directory you previously downloaded from Marquez.
 
-## Add a Script for Initializing the Database in the Docker Container
-
-In the `docker` directory, create a script `init-example-db.sh`:
-
-```sh
-#!/bin/bash
-#
-# Copyright 2018-2023 contributors to the Marquez project
-# SPDX-License-Identifier: Apache-2.0
-#
-# Usage: $ ./init-db.sh
-
-set -eu
-
-psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" > /dev/null <<-EOSQL
-  CREATE USER ${EXAMPLE_USER};
-  ALTER USER ${EXAMPLE_USER} WITH PASSWORD '${EXAMPLE_PASSWORD}';
-  CREATE DATABASE ${EXAMPLE_DB};
-  GRANT ALL PRIVILEGES ON DATABASE ${EXAMPLE_DB} TO ${EXAMPLE_USER};
-EOSQL
-```
-
-Make it executable on the command line with:
-
-```sh
-$ chmod +x init-example-db.sh
-```
-
 ## Start Airflow with Marquez
 
 Now you can start all services. To do so, execute the following:
@@ -196,7 +155,8 @@ $ astro dev start
 **The above command will:**
 
 * start Airflow
-* start the Marquez API, database and UI
+* start Marquez, including its API, database and UI
+* create and start a Postgres server for DAG tasks
 
 To view the Airflow UI and verify it's running, open [http://localhost:8080](http://localhost:8080). Then, log in using the username and password `admin` / `admin`. You can also browse to [http://localhost:3000](http://localhost:3000) to view the Marquez UI.
 

--- a/docs/guides/airflow-quickstart.md
+++ b/docs/guides/airflow-quickstart.md
@@ -15,12 +15,11 @@ In this example, we'll walk you through how to enable Airflow DAGs to send linea
 
 1. [Step 1: Configure Your Astro Project](#configure-your-astro-project)
 2. [Step 2: Add Marquez Services Using Docker Compose](#add-marquez-services-using-docker-compose)
-3. [Step 3: Add a Database Connection](#add-a-database-connection)
-4. [Step 4: Add a Script for Initializing the Database in the Docker Container](#add-a-script-for-initializing-the-database-in-the-docker-container)
-5. [Step 5: Start Airflow with Marquez](#start-airflow-with-marquez)
-6. [Step 6: Write Airflow DAGs](#write-airflow-dags)
-7. [Step 7: View Collected Metadata](#view-collected-metadata)
-8. [Step 8: Troubleshoot a Failing DAG with Marquez](#troubleshoot-a-failing-dag-with-marquez)
+3. [Step 3: Add a Script for Initializing the Database in the Docker Container](#add-a-script-for-initializing-the-database-in-the-docker-container)
+4. [Step 4: Start Airflow with Marquez](#start-airflow-with-marquez)
+5. [Step 5: Write Airflow DAGs](#write-airflow-dags)
+6. [Step 6: View Collected Metadata](#view-collected-metadata)
+7. [Step 7: Troubleshoot a Failing DAG with Marquez](#troubleshoot-a-failing-dag-with-marquez)
 
 ## Prerequisites
 
@@ -157,32 +156,6 @@ services:
 ```
 
 The above adds the Marquez API, database and Web UI, along with an additional Postgres database for the DAGs used in this example, to Astro's Docker container and configures them to use the scripts in the `docker` directory you previously downloaded from Marquez.
-
-## Add a Database Connection
-
-In `airflow_settings.yaml`, configure a database connection for Airflow:
-
-```yml
-airflow:
-  connections:
-    - conn_id: 'example_db'
-      conn_type: 'postgres'
-      conn_host: 'postgres.host.docker.internal'
-      conn_schema: 
-      conn_login: 'postgres.example'
-      conn_password: 'postgres.example'
-      conn_port: 7654
-      conn_extra:
-        example_extra_field: 
-  pools:
-    - pool_name:
-      pool_slot:
-      pool_description:
-  variables:
-    - variable_name:
-      variable_value:
-
-```
 
 ## Add a Script for Initializing the Database in the Docker Container
 


### PR DESCRIPTION
The recently added Astro/Airflow quickstart in `guides` was missing necessary database creation steps for the DAGs to succeed.

This adds a service to the `docker-compose.override.yml` along with an initialization script in the `docker` directory and other minor configuration instructions so that users can add and configure the necessary database.