### PR TITLE
add 0.29.2 release notes and fix community page

### DIFF
--- a/docs/releases/0_10_0.md
+++ b/docs/releases/0_10_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.10.0
-sidebar_position: 23
+sidebar_position: 24
 ---
 
 # 0.10.0 - 2022-06-24

--- a/docs/releases/0_11_0.md
+++ b/docs/releases/0_11_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.11.0
-sidebar_position: 22
+sidebar_position: 23
 ---
 
 # 0.11.0 - 2022-07-07

--- a/docs/releases/0_12_0.md
+++ b/docs/releases/0_12_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.12.0
-sidebar_position: 21
+sidebar_position: 22
 ---
 
 # 0.12.0 - 2022-08-01

--- a/docs/releases/0_13_0.md
+++ b/docs/releases/0_13_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.0
-sidebar_position: 20
+sidebar_position: 21
 ---
 
 # 0.13.0 - 2022-08-22

--- a/docs/releases/0_13_1.md
+++ b/docs/releases/0_13_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.13.1
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # 0.13.1 - 2022-08-25

--- a/docs/releases/0_14_0.md
+++ b/docs/releases/0_14_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.0
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # 0.14.0 - 2022-09-06

--- a/docs/releases/0_14_1.md
+++ b/docs/releases/0_14_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.14.1
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # 0.14.1 - 2022-09-07

--- a/docs/releases/0_15_1.md
+++ b/docs/releases/0_15_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.15.1
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # 0.15.1 - 2022-10-05

--- a/docs/releases/0_16_1.md
+++ b/docs/releases/0_16_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.16.1
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # 0.16.1 - 2022-11-03

--- a/docs/releases/0_17_0.md
+++ b/docs/releases/0_17_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.17.0
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # 0.17.0 - 2022-11-16

--- a/docs/releases/0_18_0.md
+++ b/docs/releases/0_18_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.18.0
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # 0.18.0 - 2022-12-08

--- a/docs/releases/0_19_2.md
+++ b/docs/releases/0_19_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.19.2
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # 0.19.2 - 2023-01-04

--- a/docs/releases/0_1_0.md
+++ b/docs/releases/0_1_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.1.0
-sidebar_position: 40
+sidebar_position: 41
 ---
 
 # 0.1.0 - 2021-08-13

--- a/docs/releases/0_20_4.md
+++ b/docs/releases/0_20_4.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.4
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # 0.20.4 - 2023-02-07

--- a/docs/releases/0_20_6.md
+++ b/docs/releases/0_20_6.md
@@ -1,6 +1,6 @@
 ---
 title: 0.20.6
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # 0.20.6 - 2023-02-10

--- a/docs/releases/0_21_1.md
+++ b/docs/releases/0_21_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.21.1
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # 0.21.1 - 2023-03-02

--- a/docs/releases/0_22_0.md
+++ b/docs/releases/0_22_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.22.0
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # 0.22.0 - 2023-04-03

--- a/docs/releases/0_23_0.md
+++ b/docs/releases/0_23_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.23.0
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # 0.23.0 - 2023-04-20

--- a/docs/releases/0_24_0.md
+++ b/docs/releases/0_24_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.24.0
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # 0.24.0 - 2023-05-03

--- a/docs/releases/0_25_0.md
+++ b/docs/releases/0_25_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.25.0
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # 0.25.0 - 2023-05-15

--- a/docs/releases/0_26_0.md
+++ b/docs/releases/0_26_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.26.0
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # 0.26.0 - 2023-05-18

--- a/docs/releases/0_27_1.md
+++ b/docs/releases/0_27_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.27.1
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # 0.27.1 - 2023-06-05

--- a/docs/releases/0_27_2.md
+++ b/docs/releases/0_27_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.27.2
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 0.27.2 - 2023-06-06

--- a/docs/releases/0_28_0.md
+++ b/docs/releases/0_28_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.28.0
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # 0.28.0 - 2023-06-12

--- a/docs/releases/0_29_2.md
+++ b/docs/releases/0_29_2.md
@@ -1,0 +1,23 @@
+---
+title: 0.29.2
+sidebar_position: 1
+---
+
+# 0.29.2 - 2023-06-30
+
+### Added
+* **Flink: support Flink version 1.17.1** [`#1947`](https://github.com/OpenLineage/OpenLineage/pull/1947) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Support Flink versions: 1.15.4, 1.16.2 and 1.17.1.*
+* **Spark: support Spark 3.4** [`#1790`](https://github.com/OpenLineage/OpenLineage/pull/1790) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Introduce support for latest Spark version 3.4.0, along with 3.2.4 and 3.3.2.*
+* **Spark: add Databricks platform integration test** [`#1928`](https://github.com/OpenLineage/OpenLineage/pull/1928) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Spark integration test to verify behaviour on databricks platform to be run manually in CircleCI when needed.*
+* **Spec: add static lineage event types** [`#1880`](https://github.com/OpenLineage/OpenLineage/pull/1880) @pawel-big-lebowski   
+    *As a first step in implementing static lineage, this adds new `DatasetEvent` and `JobEvent` types to the spec, along with support for the new types in the Python client.*
+
+### Removed
+* **Proxy: remove unused Golang client approach** [`#1926`](https://github.com/OpenLineage/OpenLineage/pull/1926) [@mobuchowski](https://github.com/mobuchowski)  
+    *Removes the unused Golang proxy, rendered redundant by the fluentd proxy.*
+* **Req: bump minimum supported Python version to 3.8** [`#1950`](https://github.com/OpenLineage/OpenLineage/pull/1950) [@mobuchowski](https://github.com/mobuchowski)  
+    *Python 3.7 is at EOL. This bumps the minimum supported version to 3.8 to keep the project aligned with the Python EOL schedule.*
+

--- a/docs/releases/0_2_0.md
+++ b/docs/releases/0_2_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.0
-sidebar_position: 39
+sidebar_position: 40
 ---
 
 # 0.2.0 - 2021-08-23

--- a/docs/releases/0_2_1.md
+++ b/docs/releases/0_2_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.1
-sidebar_position: 38
+sidebar_position: 39
 ---
 
 # 0.2.1 - 2021-08-27

--- a/docs/releases/0_2_2.md
+++ b/docs/releases/0_2_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.2
-sidebar_position: 37
+sidebar_position: 38
 ---
 
 # 0.2.2 - 2021-09-08

--- a/docs/releases/0_2_3.md
+++ b/docs/releases/0_2_3.md
@@ -1,6 +1,6 @@
 ---
 title: 0.2.3
-sidebar_position: 36
+sidebar_position: 37
 ---
 
 # 0.2.3 - 2021-10-07

--- a/docs/releases/0_3_0.md
+++ b/docs/releases/0_3_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.0
-sidebar_position: 35
+sidebar_position: 36
 ---
 
 # 0.3.0 - 2021-12-03

--- a/docs/releases/0_3_1.md
+++ b/docs/releases/0_3_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.3.1
-sidebar_position: 34
+sidebar_position: 35
 ---
 
 # 0.3.1 - 2021-12-03

--- a/docs/releases/0_4_0.md
+++ b/docs/releases/0_4_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.4.0
-sidebar_position: 33
+sidebar_position: 34
 ---
 
 # 0.4.0 - 2021-12-13

--- a/docs/releases/0_5_1.md
+++ b/docs/releases/0_5_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.1
-sidebar_position: 32
+sidebar_position: 33
 ---
 
 # 0.5.1 - 2022-01-18

--- a/docs/releases/0_5_2.md
+++ b/docs/releases/0_5_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.5.2
-sidebar_position: 31
+sidebar_position: 32
 ---
 
 # 0.5.2 - 2022-02-10

--- a/docs/releases/0_6_0.md
+++ b/docs/releases/0_6_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.0
-sidebar_position: 30
+sidebar_position: 31
 ---
 
 # 0.6.0 - 2022-03-04

--- a/docs/releases/0_6_1.md
+++ b/docs/releases/0_6_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.1
-sidebar_position: 29
+sidebar_position: 30
 ---
 
 # 0.6.1 - 2022-03-07

--- a/docs/releases/0_6_2.md
+++ b/docs/releases/0_6_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.6.2
-sidebar_position: 28
+sidebar_position: 29
 ---
 
 # 0.6.2 - 2022-03-16

--- a/docs/releases/0_7_1.md
+++ b/docs/releases/0_7_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.7.1
-sidebar_position: 27
+sidebar_position: 28
 ---
 
 # 0.7.1 - 2022-04-19

--- a/docs/releases/0_8_1.md
+++ b/docs/releases/0_8_1.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.1
-sidebar_position: 26
+sidebar_position: 27
 ---
 
 # 0.8.1 - 2022-04-29

--- a/docs/releases/0_8_2.md
+++ b/docs/releases/0_8_2.md
@@ -1,6 +1,6 @@
 ---
 title: 0.8.2
-sidebar_position: 25
+sidebar_position: 26
 ---
 
 # 0.8.2 - 2022-05-19

--- a/docs/releases/0_9_0.md
+++ b/docs/releases/0_9_0.md
@@ -1,6 +1,6 @@
 ---
 title: 0.9.0
-sidebar_position: 24
+sidebar_position: 25
 ---
 
 # 0.9.0 - 2022-06-03

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -22,6 +22,7 @@ import Footer from '@site/src/components/footer';
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
 | <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">June 22, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">Data Lineage Meetup at Collibra HQ</div> |
 | <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
 | <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
 | <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |


### PR DESCRIPTION
This adds release notes for 0.29.2 and updates all sidebar positions accordingly. Also included: a fix to the community page to add a missing meetup to the meetups table.