### PR TITLE
add escaping and spacing for asterisk references

### DIFF
--- a/docs/integrations/about.md
+++ b/docs/integrations/about.md
@@ -26,9 +26,9 @@ An empty column means it is not yet documented if the mechanism implements this 
 | Spark              | SparkListener     | Schema<br />Row count<br /> Column lineage    | ✔️                 |                    |             |                    |                        |                                     |                                   |                    |                       |                           |                            |                       |                |
 | Snowflake***       | Access History    | Lineage                                       |                   |                    |             |                    |                        |                                     |                                   |                    |                       |                           |                            |                       |                |
 
-* Uses the Rest SQL parser
-** Uses the BigQuery API
-*** Uses Snowflake query logs
+\* Uses the Rest SQL parser  
+\*\* Uses the BigQuery API  
+\*\*\* Uses Snowflake query logs
 
 ## Compatibility matrix
 


### PR DESCRIPTION
This PR add some escaping and explicit line breaks to the asterisk references on this page, so they're displayed as intended.

Currently, the asterisk are being interpreted as both bullets and emphasis and resulting in this:

![image](https://github.com/OpenLineage/docs/assets/3192745/ff2e51f1-5361-43b2-b5d4-fee5ce42550d)
