### PR TITLE
add cname file as prerequisite for adding cloudflare

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+openlineage.io


### PR DESCRIPTION
Given the inability to configure GitHub Pages to add secure headers to a site with a custom domain (see [this thread](https://github.com/orgs/community/discussions/4444)), a third-party solution is required.

Cloudflare, which offers a free tier, appears to be the most common solution. As a first step in [implementing](https://blog.cloudflare.com/secure-and-fast-github-pages-with-cloudflare/) it, this adds a required CNAME file to the root directory. 