### PR TITLE
update docusaurus.config.js with new url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,9 +23,9 @@ const linksSocial = [
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'OpenLineage Docs',
-  tagline: 'OpenLineage Docs',
-  url: 'https://docs.openlineage.io',
+  title: 'OpenLineage',
+  tagline: 'OpenLineage',
+  url: 'https://openlineage.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
@@ -119,7 +119,7 @@ const config = {
     ({
       navbar: {
         logo: {
-          alt: 'OpenLineage Docs',
+          alt: 'OpenLineage',
           src: 'img/ol-logo.svg',
         },
         items: [


### PR DESCRIPTION
The `docusaurus.config.js` file sets the site URL using the docs subdomain (`docs.openlineage.io`), which no longer reflects the site's URL. It is possible that this configuration is the reason we are having trouble adding security headers to the site.

This updates the config with the correct URL and title of the site.