### PR TITLE
add `_headers` file to add security headers on Cloudflare

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+  Content-Security-Policy-Report-Only: script-src 'self'


### PR DESCRIPTION
Cloudflare supports adding custom headers with a `_headers` file in the root of the build directory.

This adds security headers in this file with a `Content-Security-Policy-Report-Only` key for testing a `content-security-policy` header. The value will not be enforced.