### PR TITLE
add support for additional author metadata in blog posts

### DIFF
--- a/blog/0.1-release/index.mdx
+++ b/blog/0.1-release/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Introducing OpenLineage 0.1.0
 date: 2021-09-03
-author: Julien Le Dem
+authors: 
+  - name: Julien Le Dem
+    title: OpenLineage Project Lead
+    url: https://www.github.com/julienledem/
 image: ./image.svg
 banner: ./banner.svg
 description: We are pleased to announce the initial release of OpenLineage. This release includes the core specification, data model, clients, and integrations with common data tools.

--- a/blog/1.0-release/index.mdx
+++ b/blog/1.0-release/index.mdx
@@ -2,7 +2,7 @@
 title: Announcing OpenLineage 1.0
 date: 2023-08-04
 authors: 
-    name: Shirley Lu
+  - name: Shirley Lu
     title: Guest Blogger
     url: https://www.linkedin.com/in/juye-shirley-lu/
 image: ./image.svg

--- a/blog/backfilling-airflow-dags-using-marquez/index.mdx
+++ b/blog/backfilling-airflow-dags-using-marquez/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Backfilling Airflow DAGs using Marquez
 date: 2021-06-30
-author: Willy Lulciuc
+authors: 
+  - name: Willy Lulciuc
+    title: Marquez Project Lead and OpenLineage Committer
+    url: https://www.github.com/wslulciuc
 image: ./image.svg
 banner: ./banner.svg
 description: In this blog post, we'll discuss how lineage metadata can be used to automatically backfill DAGs with complex upstream and downstream dependencies.

--- a/blog/column-lineage/index.mdx
+++ b/blog/column-lineage/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: The Current State of Column-level Lineage
 date: 2022-09-02
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: Column-level lineage helps organizations navigate a complex regulatory landscape.

--- a/blog/data-agility-day/index.mdx
+++ b/blog/data-agility-day/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Video - OpenLineage at Data Agility Day
 date: 2021-11-17
-author: Ross Turk
+authors: 
+  - name: Ross Turk
+    title: OpenLineage Committer
+    url: https://www.github.com/rossturk
 image: ./image.svg
 banner: ./banner.svg
 description: At Data Agility Day 2021, Julien Le Dem and Kevin Mellott outlined their approach to data lineage and discussed various approaches to implementing it in the real world.

--- a/blog/data-council-meetup/index.mdx
+++ b/blog/data-council-meetup/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Meet Us at Data Council Austin
 date: 2023-02-28
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The OpenLineage community will be gathering on March 30th at Data Council Austin -- join us!

--- a/blog/data-lineage-meetup/index.mdx
+++ b/blog/data-lineage-meetup/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Happening Soon - Our First Meetup!
 date: 2023-02-08
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The inaugural Data Lineage Meetup will take place on March 9th in Providence, RI.

--- a/blog/dataquality_expectations_facet/index.mdx
+++ b/blog/dataquality_expectations_facet/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Expecting Great Quality with OpenLineage Facets
 date: 2021-08-12
-author: Michael Collado
+authors: 
+  - name: Michael Collado
+    title: OpenLineage Committer
+    url: https://www.github.com/collado-mike
 image: ./image.svg
 banner: ./banner.svg
 description: Good data is paramount to making good decisions- but how can you trust the quality of your data and its dependencies?

--- a/blog/dbt-with-marquez/index.mdx
+++ b/blog/dbt-with-marquez/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Using Marquez to Visualize dbt Models
 date: 2021-09-21
-author: Ross Turk
+authors: 
+  - name: Ross Turk
+    title: OpenLineage Committer
+    url: https://www.github.com/rossturk
 image: ./image.svg
 banner: ./banner.svg
 description: Each time dbt runs, it generates a trove of metadata about datasets and the work it performs with them. In this post, I’d like to show you how to harvest this metadata and put it to good use.

--- a/blog/ecosystem-survey/index.mdx
+++ b/blog/ecosystem-survey/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: 2023 Ecosystem Survey
 date: 2023-05-23
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The 2023 Ecosystem Survey will provide us with important information about our users, their opinions and needs.

--- a/blog/explore-lineage-api/index.mdx
+++ b/blog/explore-lineage-api/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Exploring Lineage History via the Marquez API
 date: 2021-07-08
-author: Michael Collado
+authors: 
+  - name: Michael Collado
+    title: OpenLineage Committer
+    url: https://www.github.com/collado-mike
 image: ./image.svg
 banner: ./banner.svg
 description: Taking advantage of recent changes to the Marquez API, this post shows how to diagnose job failures and explore the impact of code changes on downstream dependents.

--- a/blog/extending-with-facets/index.mdx
+++ b/blog/extending-with-facets/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Extending OpenLineage with Facets
 date: 2021-07-27
-author: Julien Le Dem
+authors: 
+  - name: Julien Le Dem
+    title: OpenLineage Project Lead
+    url: https://www.github.com/julienledem/
 image: ./image.svg
 banner: ./banner.svg
 description: Facets are a self-contained definition of one aspect of a job, dataset, or run at the time the event happened. They make the OpenLineage model extensible.

--- a/blog/extractors/index.mdx
+++ b/blog/extractors/index.mdx
@@ -1,7 +1,13 @@
 ---
 title: Pursuing Lineage from Airflow using Custom Extractors
 date: 2022-09-08
-author: Maciej Obuchowski & Michael Robinson
+authors: 
+  - name: Maciej Obuchowski 
+    title: OpenLineage Committer
+    url: https://www.github.com/mobuchowski
+  - name: Michael Robinson
+    title: OpenLineage Committer 
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: Built-in support for custom extractors makes OpenLineage a highly adaptable solution for pipelines that use Airflow.

--- a/blog/incubation-stage-lfai/index.mdx
+++ b/blog/incubation-stage-lfai/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: OpenLineage Advances to Incubation Stage with the LFAI & Data
 date: 2023-01-17
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: OpenLineage has achieved Incubation status with the LFAI & Data.

--- a/blog/joining-lfai/index.mdx
+++ b/blog/joining-lfai/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: OpenLineage joins the LF AI & Data Foundation
 date: 2021-07-22
-author: Julien Le Dem
+authors: 
+  - name: Julien Le Dem
+    title: OpenLineage Project Lead
+    url: https://www.github.com/julienledem/
 image: ./image.svg
 banner: ./banner.svg
 description: Becoming a LF AI & Data project ensures that OpenLineage can never belong to a company, or even a group of developers; it belongs to us all.

--- a/blog/manta-integration/index.mdx
+++ b/blog/manta-integration/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: At MANTA, OpenLineage Opens Doors to New Insights
 date: 2022-10-31
-author: Ernie Ostic, SVP of Product at MANTA
+authors: 
+  - name: Ernie Ostic
+    title: SVP of Product at MANTA
 image: ./image.svg
 banner: ./banner.svg
 description: Adopting OpenLineage as part of our portfolio allows MANTA to bring detailed run-time lineage to our customers.

--- a/blog/nyc-collibra-meetup/index.mdx
+++ b/blog/nyc-collibra-meetup/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Join us in New York on June 22nd
 date: 2023-06-08
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: A meetup is happening on June 22nd in New York. Please join us!

--- a/blog/nyc-meetup/index.mdx
+++ b/blog/nyc-meetup/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Meet Us in NYC Later This Month!
 date: 2023-04-04
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The next OpenLineage Meetup will take place on April 26th in NYC.

--- a/blog/openlineage-at-northwestern-mutual/index.mdx
+++ b/blog/openlineage-at-northwestern-mutual/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: How Northwestern Mutual Simplified Data Observability with OpenLineage & Marquez
 date: 2021-10-22
-author: Kevin Mellott
+authors: 
+  - name: Kevin Mellott
+    title: Guest Blogger and OpenLineage Contributor
 image: ./image.svg
 banner: ./banner.svg
 description: Northwestern Mutual is building an Enterprise Data Platform. In this guest blog, learn about the experiences and decisions that led them to embrace the OpenLineage and Marquez communities.

--- a/blog/openlineage-egeria/index.mdx
+++ b/blog/openlineage-egeria/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: OpenLineage Support in Egeria
 date: 2022-04-25
-author: Mandy Chessel
+authors: 
+  - name: Mandy Chessel
+    title: Guest Blogger and OpenLineage Committer
 image: ./image.svg
 banner: ./banner.svg
 description: The Egeria project uses OpenLineage to enhance its production of holistic metadata about an organization's operations.

--- a/blog/openlineage-microsoft-purview/index.mdx
+++ b/blog/openlineage-microsoft-purview/index.mdx
@@ -1,7 +1,13 @@
 ---
 title: Microsoft Purview Accelerates Lineage Extraction from Azure Databricks
 date: 2022-06-14
-author: Chandru Sugunan, Will Johnson & Michael Robinson
+authors: 
+  - name: Chandru Sugunan
+    title: Guest Blogger and OpenLineage Contributor 
+  - name: Will Johnson
+    title: Guest Blogger and OpenLineage Committer
+  - name: Michael Robinson
+    title: OpenLineage Committer
 image: ./image.svg
 banner: ./banner.svg
 description: A new collaboration between Microsoft and OpenLineage is making lineage extraction possible for Azure Databricks and Microsoft Purview users.

--- a/blog/openlineage-snowflake/index.mdx
+++ b/blog/openlineage-snowflake/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Data Lineage with Snowflake
 date: 2022-04-27
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The OpenLineage Adapter offers Snowflake's enterprise users a powerful tool for analyzing their pipelines.

--- a/blog/openlineage-spark/index.mdx
+++ b/blog/openlineage-spark/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Tracing Data Lineage with OpenLineage and Apache Spark
 date: 2021-11-05
-author: Michael Collado
+authors: 
+  - name: Michael Collado
+    title: OpenLineage Committer
+    url: https://www.github.com/collado-mike
 image: ./image.svg
 banner: ./banner.svg
 description: Spark ushered in a brand new age of data democratization... and left us with a mess of hidden dependencies, stale datasets, and failed jobs.

--- a/blog/openlineage-takes-inspiration-from-opentelemetry/index.mdx
+++ b/blog/openlineage-takes-inspiration-from-opentelemetry/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: How OpenLineage takes inspiration from OpenTelemetry
 date: 2021-06-20
-author: Julien Le Dem
+authors: 
+  - name: Julien Le Dem
+    title: OpenLineage Project Lead
+    url: https://www.github.com/julienledem/
 image: ./image.svg
 banner: ./banner.svg
 description: The data world and the service world have many similarities but also a few crucial differences. 

--- a/blog/operators-and-extractors-technical-deep-dive/index.mdx
+++ b/blog/operators-and-extractors-technical-deep-dive/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: How Operators and Extractors Work Under-the-Hook
 date: 2022-09-07
-author: Benji Lampel
+authors: 
+  - name: Benji Lampel
+    title: OpenLineage Committer 
+    url: https://www.github.com/denimalpaca
 image: ./image.svg
 banner: ./banner.svg
 description: A technical deep-dive on how the Airflow OSS and OpenLineage OSS projects interact. 

--- a/blog/python-client/index.mdx
+++ b/blog/python-client/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: The Python Client -- the Foundation of OpenLineage Integrations
 date: 2022-07-29
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The Python client enables users to create custom integrations.

--- a/blog/sf-meetup-2/index.mdx
+++ b/blog/sf-meetup-2/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Meet Us in San Francisco on August 30th!
 date: 2023-08-02
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: Our second SF OpenLineage Meetup will take place on August 30th.

--- a/blog/sf-meetup/index.mdx
+++ b/blog/sf-meetup/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Meet Us in San Francisco on June 27th!
 date: 2023-05-16
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The first SF OpenLineage Meetup will take place on June 27th.

--- a/blog/static-lineage/index.mdx
+++ b/blog/static-lineage/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: OpenLineage 1.0, Featuring Static Lineage, is Coming Soon
 date: 2023-07-18
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: The release of OpenLineage 1.0 will add static lineage support.

--- a/blog/whats-in-a-namespace/index.mdx
+++ b/blog/whats-in-a-namespace/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: What's in a Namespace?
 date: 2023-01-13
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: Namespaces enable powerful insights into distributed workflows.

--- a/blog/why-open-standard/index.mdx
+++ b/blog/why-open-standard/index.mdx
@@ -1,7 +1,10 @@
 ---
 title: Why an Open Standard for Lineage Metadata?
 date: 2023-05-22
-author: Michael Robinson
+authors: 
+  - name: Michael Robinson
+    title: OpenLineage Committer
+    url: https://www.github.com/merobi-hub
 image: ./image.svg
 banner: ./banner.svg
 description: An open standard offers the best route to a universally adopted, persistent metadata specification.

--- a/src/components/item-blog.tsx
+++ b/src/components/item-blog.tsx
@@ -7,12 +7,7 @@ export const ItemBlog = ({ data }) => {
 
     const [focused, changeFocused] = useState(false);
     const authorObjects = data.frontMatter.authors
-    const len = authorObjects.length
     const authorStrings = authorObjects.map(obj => obj.name).join(', ')
-    const authors = []
-    for (var author of authorStrings) {
-        authors.push(<small className="font-sans">{author}</small>)
-    }
     return (
         <div className="blog-item w-full md:w-1/2 lg:w-1/3 p-4">
             <div className={`transition-all duration-300 hover:shadow-2xl shadow ${focused && 'focused'}`}>
@@ -37,7 +32,7 @@ export const ItemBlog = ({ data }) => {
                             <small className="pl-2 font-sans">{getDate(data.metadata.date)}</small>
                         </div>
                         <p className="pt-3 text-color-default">
-                            <strong>{authors}</strong>
+                            <strong><small className="font-sans">{authorStrings}</small></strong>
                         </p>
                         <p className="pt-3 text-color-default">
                             {data.frontMatter.description}

--- a/src/components/item-blog.tsx
+++ b/src/components/item-blog.tsx
@@ -6,19 +6,12 @@ import { getDate } from "./utils"
 export const ItemBlog = ({ data }) => {
 
     const [focused, changeFocused] = useState(false);
-    const authorStrings = []
-    const authorObjects = Object.entries(data.frontMatter.authors)
+    const authorObjects = data.frontMatter.authors
     const len = authorObjects.length
-    for (var i = 0; i < len; i++) {
-        if ((i + 1) == (len)) {
-            authorStrings.push(authorObjects[i][1]['name'])
-        } else {
-        authorStrings.push(authorObjects[i][1]['name']+',')
-        }
-    }
+    const authorStrings = authorObjects.map(obj => obj.name).join(', ')
     const authors = []
     for (var author of authorStrings) {
-        authors.push(<small className="pl-2 font-sans">{author}</small>)
+        authors.push(<small className="font-sans">{author}</small>)
     }
     return (
         <div className="blog-item w-full md:w-1/2 lg:w-1/3 p-4">

--- a/src/components/item-blog.tsx
+++ b/src/components/item-blog.tsx
@@ -6,7 +6,11 @@ import { getDate } from "./utils"
 export const ItemBlog = ({ data }) => {
 
     const [focused, changeFocused] = useState(false);
-
+    const authors = []
+    const authorObjects = Object.entries(data.frontMatter.authors)
+    for (var author of authorObjects) {
+        authors.push(<small className="pl-2 font-sans">{author[1]['name']}</small>)
+    }
     return (
         <div className="blog-item w-full md:w-1/2 lg:w-1/3 p-4">
             <div className={`transition-all duration-300 hover:shadow-2xl shadow ${focused && 'focused'}`}>
@@ -28,7 +32,8 @@ export const ItemBlog = ({ data }) => {
                         </h4>
                         <div className="flex items-center text-color-default">
                             <Calendar className="stroke-current" />
-                            <small className="pl-2 font-sans">{getDate(data.metadata.date)} by {data.frontMatter.author}</small>
+                            <small className="pl-2 font-sans">{getDate(data.metadata.date)}</small>
+                            {authors}
                         </div>
                         <p className="pt-3 text-color-default">
                             {data.frontMatter.description}

--- a/src/components/item-blog.tsx
+++ b/src/components/item-blog.tsx
@@ -6,10 +6,19 @@ import { getDate } from "./utils"
 export const ItemBlog = ({ data }) => {
 
     const [focused, changeFocused] = useState(false);
-    const authors = []
+    const authorStrings = []
     const authorObjects = Object.entries(data.frontMatter.authors)
-    for (var author of authorObjects) {
-        authors.push(<small className="pl-2 font-sans">{author[1]['name']}</small>)
+    const len = authorObjects.length
+    for (var i = 0; i < len; i++) {
+        if ((i + 1) == (len)) {
+            authorStrings.push(authorObjects[i][1]['name'])
+        } else {
+        authorStrings.push(authorObjects[i][1]['name']+',')
+        }
+    }
+    const authors = []
+    for (var author of authorStrings) {
+        authors.push(<small className="pl-2 font-sans">{author}</small>)
     }
     return (
         <div className="blog-item w-full md:w-1/2 lg:w-1/3 p-4">
@@ -33,8 +42,10 @@ export const ItemBlog = ({ data }) => {
                         <div className="flex items-center text-color-default">
                             <Calendar className="stroke-current" />
                             <small className="pl-2 font-sans">{getDate(data.metadata.date)}</small>
-                            {authors}
                         </div>
+                        <p className="pt-3 text-color-default">
+                            <strong>{authors}</strong>
+                        </p>
                         <p className="pt-3 text-color-default">
                             {data.frontMatter.description}
                         </p>

--- a/src/components/item-blog.tsx
+++ b/src/components/item-blog.tsx
@@ -7,7 +7,7 @@ export const ItemBlog = ({ data }) => {
 
     const [focused, changeFocused] = useState(false);
     const authorObjects = data.frontMatter.authors
-    const authorStrings = authorObjects.map(obj => obj.name).join(', ')
+    const author = authorObjects.map(obj => obj.name).join(', ')
     return (
         <div className="blog-item w-full md:w-1/2 lg:w-1/3 p-4">
             <div className={`transition-all duration-300 hover:shadow-2xl shadow ${focused && 'focused'}`}>
@@ -32,7 +32,7 @@ export const ItemBlog = ({ data }) => {
                             <small className="pl-2 font-sans">{getDate(data.metadata.date)}</small>
                         </div>
                         <p className="pt-3 text-color-default">
-                            <strong><small className="font-sans">{authorStrings}</small></strong>
+                            <strong><small className="font-sans">{author}</small></strong>
                         </p>
                         <p className="pt-3 text-color-default">
                             {data.frontMatter.description}


### PR DESCRIPTION
The blog does not make full use of the author metadata fields available from Docusaurus, including differently formatted titles for authors and URLs for GitHub profiles, etc.

This:
- refactors the existing author metadata across the blog to use the more detailed `authors` field
- adds support in the `item-blog` component for this refactored metadata.

![Screenshot 2023-08-07 at 14 43 50](https://github.com/OpenLineage/docs/assets/68482867/8a5678c8-5e29-45ea-8313-89790e987a03)
![Screenshot 2023-08-07 at 18 41 24](https://github.com/OpenLineage/docs/assets/68482867/854bad59-cfdf-4202-b72d-993df38d9732)