### PR TITLE
update Slack link

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -55,7 +55,7 @@ import Footer from '@site/src/components/footer';
 <div className="text-center pt-8"><h2>Slack</h2></div>
 <div className="container text-center">
     <div className="row">
-        <p>Join us on the <a href="http://bit.ly/OpenLineageSlack">OpenLineage Slack</a> to stay up-to-date on upcoming events, releases and discussions. The Slack community is a great place to ask questions and get to know OpenLineage contributors and users around the world.</p>
+        <p>Join us on the <a href="https://bit.ly/lineageslack">OpenLineage Slack</a> to stay up-to-date on upcoming events, releases and discussions. The Slack community is a great place to ask questions and get to know OpenLineage contributors and users around the world.</p>
     </div>
 </div>
 


### PR DESCRIPTION
The Community page is using our old Slack invite link.