### PR TITLE
Fix newsletter link on home page

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
-import Layout from '@theme/Layout';
+import Layout from '@theme/Layout'
 import { Button } from "../components/ui"
 import ItemBlog from "../components/item-blog"
 import Footer from "../components/footer"
@@ -220,8 +220,8 @@ const Newsletter = () => {
 
               <Button
                   title="Newsletter"
-                  to='bit.ly/OL_news'
-                  type="extbutton"
+                  to='https://bit.ly/OL_news'
+                  type="link"
                   iconRight={<Inbox />}
                   className="mx-5"
               />


### PR DESCRIPTION
The newsletter link on the home page was being treated as a file path. This changes the button type to a link in order to change the behavior.