### PR TITLE
Add newsletter archive link to home & rename links.

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -219,8 +219,16 @@ const Newsletter = () => {
               </p>
 
               <Button
-                  title="Newsletter"
+                  title="Sign up"
                   to='https://bit.ly/OL_news'
+                  type="link"
+                  iconRight={<Inbox />}
+                  className="mx-5"
+              />
+
+              <Button
+                  title="Archive"
+                  to="https://bit.ly/OL_news_archive"
                   type="link"
                   iconRight={<Inbox />}
                   className="mx-5"


### PR DESCRIPTION
This adds a link to the Mailchimp newsletter archive on the home page and improves the link naming there, as well.