### PR TITLE
Update meetups table on the Community page

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -16,16 +16,19 @@ import Footer from '@site/src/components/footer';
 </div>
 
 <div className="text-center pt-8"><h2>Meetups</h2></div>
-<p>In-person meetups are an exciting, new aspect of the OpenLineage community, and more events are planned. Get in touch with the <a href="mailto:michael.robinson@astronomer.io">community team</a> if you are interested in hosting a meetup in your area.</p>
+<p className="text-center">Get in touch with the <a href="mailto:michael.robinson@astronomer.io">community team</a> if you are interested in hosting a meetup in your area.</p>
 <div className="container"><div className="row"><div className="col">
 
 | <div class="text-xl pl-10 pr-10">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |
-| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
-| <div class="text-xl p-10">June 22, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">Data Lineage Meetup at Collibra HQ</div> |
-| <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
-| <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
-| <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |
+| <div class="text-xl p-10">October 5, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA, US</div> | <div class="text-xl pl-10 pr-10">Marquez Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">September 18, 2023</div> | <div class="text-xl pl-10 pr-10">Toronto, ON, CAN</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Airflow Summit</div> |
+| <div class="text-xl p-10">August 30, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA, US</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">June 27, 2023</div> | <div class="text-xl pl-10 pr-10">San Francisco, CA, US</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">June 22, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY, US</div> | <div class="text-xl pl-10 pr-10">Data Lineage Meetup at Collibra HQ</div> |
+| <div class="text-xl p-10">April 26, 2023</div> | <div class="text-xl pl-10 pr-10">New York, NY, US</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Astronomer HQ</div> |
+| <div class="text-xl p-10">March 30, 2023</div> | <div class="text-xl pl-10 pr-10">Austin, TX, US</div> | <div class="text-xl pl-10 pr-10">OpenLineage Meetup at Data Council Austin</div> |
+| <div class="text-xl p-10">March 9, 2023</div> | <div class="text-xl pl-10 pr-10">Providence, RI, US</div> | <div class="text-xl pl-10 pr-10">Inaugural Data Lineage Meetup in downtown PVD</div> |
 
 </div></div></div>
 


### PR DESCRIPTION
The Meetups table on the Community page is not current.

This adds missing meetups and tweaks the info in the table to make it less US-centric. 