### PR TITLE
Fix `spark.md` title and employ head components for titles

### DIFF
--- a/docs/integrations/airflow/default-extractors.md
+++ b/docs/integrations/airflow/default-extractors.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Exposing lineage in Airflow operators
+title: Exposing Lineage in Airflow Operators
 ---
 
 OpenLineage 0.17.0+ makes adding lineage to your data pipelines easy through support of direct modification of Airflow operators. This means that custom operators—built in-house or forked from another project—can provide you and your team with lineage data without requiring modification of the OpenLineage project. The data will still go to your lineage backend of choice, most commonly using the `OPENLINEAGE_URL` environment variable.

--- a/docs/integrations/airflow/extractors/custom-extractors.md
+++ b/docs/integrations/airflow/extractors/custom-extractors.md
@@ -1,8 +1,7 @@
 ---
 sidebar_position: 1
+title: Custom Extractors
 ---
-
-# Custom extractors
 
 This integration works by detecting which Airflow operators your DAG is using, and extracting lineage data from them using corresponding extractors.
 

--- a/docs/integrations/airflow/extractors/extractor-testing.md
+++ b/docs/integrations/airflow/extractors/extractor-testing.md
@@ -1,8 +1,7 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
+title: Testing Custom Extractors
 ---
-
-# Testing custom extractors
 
 OpenLineage comes with a variety of extractors for Airflow operators out of the box, but not every operator is covered. And if you are using a custom operator you or your team wrote, you'll certainly need to write a custom extractor. This guide will walk you through how to set up testing in a local dev environment, the most important data structures to write tests for, unit testing private functions, and some notes on troubleshooting.
 

--- a/docs/integrations/airflow/manual.md
+++ b/docs/integrations/airflow/manual.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Manually annotated lineage
+title: Manually Annotated Lineage
 ---
 
 :::caution

--- a/docs/integrations/airflow/older.md
+++ b/docs/integrations/airflow/older.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Using OpenLineage with older versions of Airflow
+title: Using OpenLineage with Older Versions of Airflow
 ---
 
 For Airflow 2.3+ OpenLineage integration automatically registers itself. Nothing else is required besides specifying where OpenLineage events should end up. However, some additional configuration is required for older OpenLineage versions.

--- a/docs/integrations/airflow/usage.md
+++ b/docs/integrations/airflow/usage.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Using the Airflow integration
+title: Using the Airflow Integration
 ---
 
 #### PREREQUISITES

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -1,8 +1,7 @@
 ---
 sidebar_position: 5
+title: dbt
 ---
-
-# dbt
 
 dbt (data build tool) is a powerful transformation engine. It operates on data already within a warehouse, making it easy for data engineers to build complex pipelines from the comfort of their laptops. While it doesn’t perform extraction and loading of data, it’s extremely powerful at transformations.
 

--- a/docs/integrations/flink.md
+++ b/docs/integrations/flink.md
@@ -1,8 +1,7 @@
 ---
 sidebar_position: 4
+title: Apache Flink
 ---
-
-# Apache Flink
 
 :::caution
 This integration is considered experimental: only specific workflows and use cases are supported.

--- a/docs/integrations/great-expectations.md
+++ b/docs/integrations/great-expectations.md
@@ -1,8 +1,7 @@
 ---
 sidebar_position: 6
+title: Great Expectations
 ---
-
-# Great Expectations
 
 Great Expectations is a robust data quality tool. It runs suites of checks, called expectations, over a defined dataset. This dataset can be a table in a database, or a Spark or Pandas dataframe. Expectations are run by checkpoints, which are configuration files that describe not just the expectations to use, but also any batching, runtime configurations, and, importantly, the action list of actions run after the expectation suite completes.
 

--- a/docs/integrations/spark/quickstart_databricks.md
+++ b/docs/integrations/spark/quickstart_databricks.md
@@ -1,8 +1,7 @@
 ---
 sidebar_position: 2
+title: Quickstart with Databricks
 ---
-
-# Quickstart with Databricks
 
 OpenLineage's [Spark Integration](https://github.com/OpenLineage/OpenLineage/blob/a2d39a7a6f02474b2dfd1484f3a6d2810a5ffe30/integration/spark/README.md) can be installed on Databricks leveraging `init` scripts. Please note, Databricks on Google Cloud does not currently support the DBFS CLI, so the proposed solution will not work on Google Cloud until that feature is enabled. 
 
@@ -10,7 +9,7 @@ OpenLineage's [Spark Integration](https://github.com/OpenLineage/OpenLineage/blo
 * [GCP Databricks Init Scripts](https://docs.gcp.databricks.com/clusters/init-scripts.html)
 * [AWS Databricks Init Scripts](https://docs.databricks.com/clusters/init-scripts.html)
 
-### Enable OpenLineage
+## Enable OpenLineage
 
 Follow the steps below to enable OpenLineage on Databricks.
 
@@ -36,7 +35,7 @@ Follow the steps below to enable OpenLineage on Databricks.
 Please note that the `init` script approach is currently obligatory to install OpenLineage on Databricks. The Openlineage integration relies on providing a custom extra listener class `io.openlineage.spark.agent.OpenLineageSparkListener` that has to be available on the classpath at the driver startup. Providing it with `spark.jars.packages` does not work on the Databricks platform as of August 2022.  
 :::
 
-### Verify Initialization
+## Verify Initialization
 
 A successful initialization will emit logs in the `Log4j output` that look similar to the following:
 
@@ -48,7 +47,7 @@ YY/MM/DD HH:mm:ss INFO OpenLineageContext: Init OpenLineageContext: Args: Argume
 YY/MM/DD HH:mm:ss INFO AsyncEventQueue: Process of event SparkListenerApplicationStart(Databricks Shell,Some(app-XXX-0000),YYYY,root,None,None,None) by listener OpenLineageSparkListener took Xs.
 ```
 
-### Create a Dataset
+## Create a Dataset
 
 Open a notebook and create an example dataset with:
 ```python
@@ -58,7 +57,7 @@ spark.createDataFrame([
 ]).write.mode("overwrite").saveAsTable("default.temp")
 ```
 
-### Observe OpenLineage Events
+## Observe OpenLineage Events
 
 To troubleshoot or observe OpenLineage information in Databricks, see the `Log4j output` in the Cluster definition's `Driver Logs`.
 

--- a/docs/integrations/spark/quickstart_local.md
+++ b/docs/integrations/spark/quickstart_local.md
@@ -1,8 +1,7 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
+title: Quickstart with Jupyter
 ---
-
-# Quickstart with Jupyter
 
 Trying out the Spark integration is super easy if you already have Docker Desktop and git installed. 
 

--- a/docs/integrations/spark/spark.md
+++ b/docs/integrations/spark/spark.md
@@ -1,13 +1,11 @@
 ---
 sidebar_position: 1
+title: Apache Spark
 ---
-
 
 :::info
 This integation is known to work with Apache Spark 2.4 and later.
 :::
-
-# Apache Spark
 
 Spark jobs typically run on clusters of machines. A single machine hosts the "driver" application,
 which constructs a graph of jobs - e.g., reading data from a source, filtering, transforming, and

--- a/docs/integrations/spark/spark_column_lineage.md
+++ b/docs/integrations/spark/spark_column_lineage.md
@@ -1,13 +1,11 @@
 ---
 sidebar_position: 3
+title: Column-level Lineage
 ---
-
-# Column Level Lineage
 
 :::info
 Column level lineage for Spark is turned on by default and requires no additional work to be done. The following documentation describes its internals. 
 :::
-
 
 Column level lineage provides fine grained information on datasets' dependencies. Not only do we know the dependency exists, but we are also able to understand which input columns are used to produce output columns. This allows for answering questions like *Which root input columns are used to construct column x?* 
 


### PR DESCRIPTION
The main doc in the Spark integration docs is displaying the file name as the title above the actual title in the doc.

This:

- fixes this by using `title` in the helmet/head component to define the title and removing the other title there
- employs the head component across the docs for consistency
- fixes position numbers where needed
- includes other minor tweaks

![Screenshot 2023-10-27 at 12 25 48](https://github.com/OpenLineage/docs/assets/68482867/88d117f6-3611-4dde-9836-6e6e09b34bfb)
