### PR TITLE
fix: update spark-submit example with proper set of configuration options

### DIFF
--- a/docs/integrations/spark/spark.md
+++ b/docs/integrations/spark/spark.md
@@ -70,6 +70,7 @@ The listener can be enabled by adding the following configuration to a `spark-su
 ```bash
 spark-submit --conf "spark.extraListeners=io.openlineage.spark.agent.OpenLineageSparkListener" \
     --packages "io.openlineage:openlineage-spark:<spark-openlineage-version>" \
+    --conf "spark.openlineage.transport.type=http" \
     --conf "spark.openlineage.transport.url=http://{openlineage.client.host}/api/v1/namespaces/spark_integration/" \
     --class com.mycompany.MySparkApp my_application.jar
 ```


### PR DESCRIPTION
since the example is using openlineage api published via http endpoint then we need to reconfigure **spark.openlineage.transport.type** from default (console) to http. otherwise this example won't work.