### PR TITLE
Add 1.7.0 release notes

### DIFF
--- a/docs/releases/1_7_0.md
+++ b/docs/releases/1_7_0.md
@@ -1,0 +1,34 @@
+---
+title: 1.7.0
+sidebar_position: 9950
+---
+
+# 1.7.0 - 2023-12-21
+
+_COMPATIBILITY NOTICE_  
+Starting in 1.7.0, the Airflow integration will no longer support Airflow versions `>=2.8.0`.  
+Please use the [OpenLineage Airflow Provider](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html) instead.
+
+### Added
+* **Airflow: add parent run facet to `COMPLETE` and `FAIL` events in Airflow integration** [`#2320`](https://github.com/OpenLineage/OpenLineage/pull/2320) [@kacpermuda](https://github.com/kacpermuda)  
+    *Adds a parent run facet to all events in the Airflow integration.*
+
+### Fixed
+* **Airflow: repair up.sh for MacOS** [`#2316`](https://github.com/OpenLineage/OpenLineage/pull/2316) [`#2318`](https://github.com/OpenLineage/OpenLineage/pull/2318) [@kacpermuda](https://github.com/kacpermuda)  
+    *Some scripts were not working well on MacOS. This adjusts them.*
+* **Airflow: repair `run_id` for `FAIL` event in Airflow 2.6+** [`#2305`](https://github.com/OpenLineage/OpenLineage/pull/2305) [@kacpermuda](https://github.com/kacpermuda)  
+    *The `Run_id` in a `FAIL` event was different than in the `START` event for Airflow 2.6+.*
+* **Flink: open Iceberg `TableLoader` before loading a table** [`#2314`](https://github.com/OpenLineage/OpenLineage/pull/2314) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Fixes a potential `NullPointerException` in 1.17 when dealing with Iceberg sinks.*
+* **Flink: name Kafka datasets according to the naming convention** [`#2321`](https://github.com/OpenLineage/OpenLineage/pull/2321) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Adds a `kafka://` prefix to Kafka topic datasets' namespaces.*
+* **Flink: fix properties within `JobTypeJobFacet`** [`#2325`](https://github.com/OpenLineage/OpenLineage/pull/2325) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Fixes properties assignment in the Flink visitor.*
+* **Spark: fix `commons-logging` relocate in target jar** [`#2319`](https://github.com/OpenLineage/OpenLineage/pull/2319) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Avoids relocating a dependency that was getting excluded from the jar.*
+* **Spec: fix inconsistency with Redshift authority format** [`#2315`](https://github.com/OpenLineage/OpenLineage/pull/2315) [@davidjgoss](https://github.com/davidjgoss)  
+    *Amends the `Authority` format for consistency with other references in the same section.*
+
+### Removed
+* **Airflow: remove Airflow 2.8+ support** [`#2330`](https://github.com/OpenLineage/OpenLineage/pull/2330) [@kacpermuda](https://github.com/kacpermuda)  
+    *To encourage use of the Provider, this removes the listener from the plugin if the Airflow version is `>=2.8.0`.*

--- a/docs/releases/1_7_0.md
+++ b/docs/releases/1_7_0.md
@@ -31,4 +31,5 @@ Please use the [OpenLineage Airflow Provider](https://airflow.apache.org/docs/ap
 
 ### Removed
 * **Airflow: remove Airflow 2.8+ support** [`#2330`](https://github.com/OpenLineage/OpenLineage/pull/2330) [@kacpermuda](https://github.com/kacpermuda)  
-    *To encourage use of the Provider, this removes the listener from the plugin if the Airflow version is `>=2.8.0`.*
+    *If the Airflow version is `>=2.8.0`, the Airflow integration's plugin does not import the integration's listener, disabling the external integration.*  
+    *Please use the [OpenLineage Airflow Provider](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html) instead.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mdx-js/react": "^1.6.22",
         "@mui/icons-material": "^5.14.19",
         "@mui/material": "^5.14.18",
+        "classnames": "^2.3.2",
         "clsx": "^1.2.0",
         "docusaurus-lunr-search": "^2.3.2",
         "prism-react-renderer": "^1.3.5",
@@ -5651,8 +5652,7 @@
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT"
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@mdx-js/react": "^1.6.22",
     "@mui/icons-material": "^5.14.19",
     "@mui/material": "^5.14.18",
+    "classnames": "^2.3.2",
     "clsx": "^1.2.0",
     "docusaurus-lunr-search": "^2.3.2",
     "prism-react-renderer": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,7 +3189,7 @@ ci-info@^2.0.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-classnames@^2.2.6:
+classnames@^2.2.6, classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==


### PR DESCRIPTION
This adds the 1.7.0 release notes to the releases in the docs. Necessary updates to yarn.lock, package.json and package-lock.json are also included.