### PR TITLE
Add scripts to `Head` to configure Google analytics for traffic metrics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,12 +134,18 @@ const config = {
       },
     }),
 
-  scripts:
-    [{
+  scripts: [
+    {
       src: 'https://plausible.io/js/script.js',
       defer: true,
       'data-domain': 'openlineage.io',
-    }],
+    },
+    'js/google_analytics.js',
+    {
+      src: 'https://www.googletagmanager.com/gtag/js?id=G-JWM05WR5QM',
+      async: true,
+    },
+  ],
 };
 
 module.exports = config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ const config = {
     },
     'js/google_analytics.js',
     {
-      src: 'https://www.googletagmanager.com/gtag/js?id=G-JWM05WR5QM',
+      src: 'https://www.googletagmanager.com/gtag/js?id=G-QMTWMLMX4M',
       async: true,
     },
   ],

--- a/static/js/google_analytics.js
+++ b/static/js/google_analytics.js
@@ -2,4 +2,4 @@ window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 
-gtag('config', 'G-JWM05WR5QM');
+gtag('config', 'G-QMTWMLMX4M');

--- a/static/js/google_analytics.js
+++ b/static/js/google_analytics.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-JWM05WR5QM');


### PR DESCRIPTION
This adds Google's required scripts for configuring Google Analytics to docusaurus.config and static following the guidance here: https://docusaurus.io/docs/next/api/docusaurus-config. Adding GA to the site will give us more analytics than we can currently get from Netlify, which only retains data for one month. We have had GA set up in the past but it hasn't been functional for some time -- probably since the migration to Docusaurus, etc.