### PR TITLE
Add blog post about Boston meetup with Collibra

### DIFF
--- a/blog/boston-collibra-meetup/index.mdx
+++ b/blog/boston-collibra-meetup/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Join us in Boston on March 19th
+date: 2024-02-08
+authors: [Robinson]
+description: Our first Boston Meetup will be held with Collibra on March 19th.
+---
+Join us on Tuesday, March 19th, 2024, from 5:30-8:00 pm at the Microsoft New England 
+Conference Center in Boston to learn more about the current state of lineage in general and 
+static lineage support in data catalogs in particular. Bring your ideas and 
+vision for data lineage!
+
+<!--truncate-->
+
+Food will be provided, and the meetup is open to all. Don't miss this opportunity 
+to learn about lineage, data governance, and more! We hope to see you there. 
+
+**Please [sign up](https://www.meetup.com/boston-data-lineage-meetup-group/events/298893366/) 
+to let us know you're coming.**
+
+### Agenda
+
+TBA! Watch this space and the Meetup page above for more details.
+
+### Time, Place & Format
+
+Date: March 19, 2024  
+Format: Hybrid  
+Time: 5:30-8:00 pm ET  
+Address: MSNE, [1 Memorial Dr, Cambridge, MA 02142](https://maps.app.goo.gl/FNjYLkeTwGaeeZ2HA)


### PR DESCRIPTION
This adds a blog post about the meetup in Boston with Collibra on 3/19/24. More details will be added as they become available.