### PR TITLE
Add blog post about Kafka Summit London talk

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -31,7 +31,7 @@ Le Dem:
     image_url: https://avatars.githubusercontent.com/u/367841?v=4
 
 Leszczynski:
-    name: Pawel Leszczynski
+    name: Paweł Leszczyński
     title: OpenLineage Committer
     url: https://github.com/pawel-big-lebowski
     image_url: https://github.com/pawel-big-lebowski.png

--- a/blog/kafka-summit-talk/index.mdx
+++ b/blog/kafka-summit-talk/index.mdx
@@ -1,0 +1,31 @@
+---
+title: OpenLineage Support for Streaming to Feature at Kafka Summit
+date: 2024-02-08
+authors: [Robinson]
+description: Project committers will speak about recent progress on stream processing support.
+---
+At this year's [Kafka Summit in London](https://www.kafka-summit.org/events/kafka-summit-london-2024/about), 
+two project committers, Paweł Leszczyński and Maciej Obuchowski, will give a talk entitled 
+**OpenLineage for Stream Processing** on March 19th at 2:00 PM GMT.
+
+As the [abstract available on the summit website](https://events.bizzabo.com/559905/agenda/session/1284918) 
+says, the talk will cover some of the 'many useful features completed or begun' 
+recently related to stream processing, including:
+
+- a seamless OpenLineage & Apache Flink integration, 
+- support for streaming jobs in Marquez, 
+- progress on a built-in lineage API within the Flink codebase. 
+
+As the abstract goes on to say,
+
+*Cross-platform lineage allows for a holistic overview of data flow and its dependencies 
+within organizations, including stream processing. This talk will provide an overview of 
+the most recent developments in the OpenLineage Flink integration and share what’s in store 
+for this important collaboration. This talk is a must-attend for those wishing to stay 
+up-to-date on lineage developments in the stream processing world.*
+
+Register and attend this interesting talk if you can. And keep an eye out for an 
+announcement about a recording if and when one becomes available.
+
+Thanks, Maciej and Paweł, for spreading the word about these exciting developments in 
+the project.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -521,3 +521,8 @@ img[src*="#banner"] {
   background-color: #3e3e3e;
   border-radius: 12px;
 }
+
+.commtable-col {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -20,7 +20,7 @@ import Footer from '@site/src/components/footer';
 </div>
 <p className="text-center">Get in touch with the <a href="mailto:michael.robinson@astronomer.io">community team</a> if you would like to host a meetup in your area.</p>
 
-<div className="container"><div className="row w-100%"><div className="col mx-auto">
+<div className="container"><div className="row w-100%"><div className="commtable-col">
 
 | <div class="text-xl pl-10 pr-10 w-100%">DATE</div> | <div class="text-xl pl-10 pr-10">CITY</div> | <div class="text-xl pl-10 pr-10">EVENT</div> |
 | ----------- | ----------- | ----------- |


### PR DESCRIPTION
This adds a post promoting Maciej and Pawel's upcoming talk at Kafka Summit. Also included: a styling fix for the community page to center the table there.
![Screenshot 2024-02-08 at 11 46 39](https://github.com/OpenLineage/docs/assets/68482867/ac85e58b-6629-4108-a439-3d3b7fc19176)
<img width="1444" alt="Screenshot 2024-02-08 at 16 09 51" src="https://github.com/OpenLineage/docs/assets/68482867/814a5718-b4cb-48e5-a806-7d35d8485907">

