### PR TITLE
docs: Update java, python and airflow docs

### DIFF
--- a/docs/client/python.md
+++ b/docs/client/python.md
@@ -21,35 +21,47 @@ pip install openlineage-python
 
 To install the package from source, use 
 ```
-python setup.py install
+python -m pip install .
 ```
 
 ## Configuration
 
-We recommend configuring the client with an `openlineage.yml` file that tells the client how to connect to an OpenLineage backend.
+We recommend configuring the client with an `openlineage.yml` file that contains all the
+details of how to connect to your OpenLineage backend.
 
-You can make this file available to the client three ways:
+You can make this file available to the client in three ways (the list also presents precedence of the configuration):
 
-1. Set an environment variable to a file path: `OPENLINEAGE_CONFIG=path/to/openlineage.yml`.
-2. Put the file in the working directory.
-3. Put the file in `$HOME/.openlineage`.
+1. Set an `OPENLINEAGE_CONFIG` environment variable to a file path: `OPENLINEAGE_CONFIG=path/to/openlineage.yml`.
+2. Place an `openlineage.yml` file in the current working directory (the absolute path of the directory where your script or process is currently running).
+3. Place an `openlineage.yml` file under `.openlineage/` in the user's home directory (`~/.openlineage/openlineage.yml`).
 
-In `openlineage.yml`, use a standard transport interface to specify the transport type (`http`, `console`, `kafka`, `file`, or custom) and authorization parameters:
+In `openlineage.yml`, use a standard `Transport` interface to specify the transport type 
+(`http`, `console`, `kafka`, `file`, or [custom](#custom-transport-type)) and authorization parameters.
+See the [example config file](#built-in-transport-types) for each transport type. 
 
-```
-transport:
-  type: "http"
-  url: "https://backend:5000"
-  auth:
-    type: "api_key"
-    api_key: "f048521b-dfe8-47cd-9c65-0cb07d57591e"
-```
-
-The type property (required) is a fully qualified class name that can be imported.
+If there is no config file found, the OpenLineage client looks at environment variables for [HTTP transport](#http-transport-configuration-with-environment-variables).
 
 ### Environment Variables
 
-The list of available environment varaibles can be found [here](../development/developing#environment-variables).
+The following environment variables are available to use:  
+
+| Name                       | Description                                                       | Example                 | Since  |
+|----------------------------|-------------------------------------------------------------------|-------------------------|--------|
+| OPENLINEAGE_CONFIG         | The path to the YAML configuration file                           | path/to/openlineage.yml |        |
+| OPENLINEAGE_CLIENT_LOGGING | Logging level of OpenLineage client and its child modules         | DEBUG                   |        |
+| OPENLINEAGE_DISABLED       | When `true`, OpenLineage will not emit events (default: false)    | false                   | 0.9.0  |
+| OPENLINEAGE_URL            | The URL to send lineage events to (also see OPENLINEAGE_ENDPOINT) | https://myapp.com       |        |
+| OPENLINEAGE_ENDPOINT       | Endpoint to which events are sent (default: api/v1/lineage)       | api/v2/events           |        |
+| OPENLINEAGE_API_KEY        | Token included in the Authentication HTTP header as the Bearer    | secret_token_123        |        |
+
+If you are using Airflow integration, there are additional [environment variables available](../integrations/airflow/usage.md#environment-variables).
+
+
+#### HTTP transport configuration with environment variables
+For backwards compatibility, the simplest HTTP transport configuration, with only a subset of its config, can be done with environment variables 
+(all other transport types are only configurable with YAML file). This setup can be done with the following 
+environment variables:  
+`OPENLINEAGE_URL` (required), `OPENLINEAGE_ENDPOINT` (optional, default: api/v1/lineage), `OPENLINEAGE_API_KEY` (optional).
 
 ### Built-in Transport Types
 
@@ -61,7 +73,7 @@ The list of available environment varaibles can be found [here](../development/d
 - verify - boolean specifying whether the client should verify TLS certificates from the backend. Default: true. (optional)
 - auth - dictionary specifying authentication options. Requires the type property. (optional)
   - type - string specifying the "api_key" or the fully qualified class name of your TokenProvider. (required if `auth` is provided)
-  - api_key - string setting the Authentication HTTP header as the Bearer. (required if `api_key` is set)
+  - apiKey - string setting the Authentication HTTP header as the Bearer. (required if `type` is `api_key`)
 
 Example:
 ```
@@ -71,7 +83,7 @@ transport:
   endpoint: events/receive
   auth:
     type: api_key
-    api_key: f048521b-dfe8-47cd-9c65-0cb07d57591e
+    apiKey: f048521b-dfe8-47cd-9c65-0cb07d57591e
 ```
 
 ##### Console 
@@ -126,6 +138,8 @@ transport:
 ### Custom Transport Type
 
 To implement a custom transport, follow the instructions in [`transport.py`](https://github.com/OpenLineage/OpenLineage/blob/main/client/python/openlineage/client/transport/transport.py).
+
+The `type` property (required) must be a fully qualified class name that can be imported.
 
 ## Getting Started
 

--- a/docs/development/developing/developing.md
+++ b/docs/development/developing/developing.md
@@ -24,16 +24,25 @@ that functionality from our Airflow library and [packaged it for separate use](h
 
 ### Environment Variables
 
-The following environment variables are available commonly for both Java and Python languages.
-
-|Name|Description|Since|
-|---|---|---|
-|OPENLINEAGE_API_KEY|The optional API key to be set on each lineage request. This will be set as a Bearer token in case authentication is required.||
-|OPENLINEAGE_CONFIG|The optional path to locate the configuration file. The configuration file is in YAML format. Example: `openlineage.yml`||
-|OPENLINEAGE_DISABLED|When set to `true`, will prevent OpenLineage from emitting events to the receiving backend|0.9.0|
-|OPENLINEAGE_URL|The URL for the HTTP transport of where to emit lineage events to. If not yet, no lineage data will be emitted, and event data (JSON) will be written to standard output. Example: `http://localhost:8080`||
+The list of available environment variables for **Python** can be found [here](../../client/python.md#environment-variables).
+The list of available environment variables for **Java** can be found [here](../../client/java.md#environment-variables).
 
 ### SQL parser
 
 We've created SQL parser that allows you to extract lineage from SQL statements. The parser is implemented in Rust; however, it's also available as a [Python library](https://pypi.org/project/openlineage-sql/).
 You can take a look at its code on [GitHub](https://github.com/OpenLineage/OpenLineage/tree/main/integration/sql).
+
+## Contributing
+
+If contributing changes, additions or fixes, please include the following header in any new files:
+
+```
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0 
+*/
+```
+
+There is a pre-commit step that checks license in headers for new files when pull requests are opened.
+
+Thanks for your contributions to the project!

--- a/docs/integrations/airflow/airflow.md
+++ b/docs/integrations/airflow/airflow.md
@@ -4,8 +4,11 @@ title: Apache Airflow
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](older.md#supported-airflow-versions)
 :::
 
 

--- a/docs/integrations/airflow/default-extractors.md
+++ b/docs/integrations/airflow/default-extractors.md
@@ -1,11 +1,14 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: Exposing Lineage in Airflow Operators
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](older.md#supported-airflow-versions)
 :::
 
 OpenLineage 0.17.0+ makes adding lineage to your data pipelines easy through support of direct modification of Airflow operators. This means that custom operators—built in-house or forked from another project—can provide you and your team with lineage data without requiring modification of the OpenLineage project. The data will still go to your lineage backend of choice, most commonly using the `OPENLINEAGE_URL` environment variable.

--- a/docs/integrations/airflow/extractors/custom-extractors.md
+++ b/docs/integrations/airflow/extractors/custom-extractors.md
@@ -4,8 +4,11 @@ title: Custom Extractors
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](../older.md#supported-airflow-versions)
 :::
 
 This integration works by detecting which Airflow operators your DAG is using, and extracting lineage data from them using corresponding extractors.

--- a/docs/integrations/airflow/extractors/extractor-testing.md
+++ b/docs/integrations/airflow/extractors/extractor-testing.md
@@ -4,8 +4,11 @@ title: Testing Custom Extractors
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](../older.md#supported-airflow-versions)
 :::
 
 OpenLineage comes with a variety of extractors for Airflow operators out of the box, but not every operator is covered. And if you are using a custom operator you or your team wrote, you'll certainly need to write a custom extractor. This guide will walk you through how to set up testing in a local dev environment, the most important data structures to write tests for, unit testing private functions, and some notes on troubleshooting.

--- a/docs/integrations/airflow/job-hierarchy.md
+++ b/docs/integrations/airflow/job-hierarchy.md
@@ -4,8 +4,11 @@ title: Job Hierarchy
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](older.md#supported-airflow-versions)
 :::
 
 ## Job Hierarchy

--- a/docs/integrations/airflow/manual.md
+++ b/docs/integrations/airflow/manual.md
@@ -1,11 +1,14 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Manually Annotated Lineage
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](older.md#supported-airflow-versions)
 :::
 
 :::caution

--- a/docs/integrations/airflow/older.md
+++ b/docs/integrations/airflow/older.md
@@ -1,26 +1,45 @@
 ---
-sidebar_position: 4
-title: Using OpenLineage with Older Versions of Airflow
+sidebar_position: 2
+title: Supported Airflow versions
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes.
 :::
 
-For Airflow 2.3+ OpenLineage integration automatically registers itself. Nothing else is required besides specifying where OpenLineage events should end up. However, some additional configuration is required for older OpenLineage versions.
+#### SUPPORTED AIRFLOW VERSIONS
 
-## Airflow 2.1 - 2.2
+##### Airflow 2.7+
 
-Integration for those versions has limitations: it does not support tracking failed jobs, and job starts are registered only when job ends.
+This package **should not** be used starting with Airflow 2.7.0 and **can not** be used with Airflow 2.8+. 
+It was designed as Airflow's external integration that works mainly for Airflow versions <2.7.
+For Airflow 2.7+ use the native Airflow OpenLineage provider 
+[package](https://airflow.apache.org/docs/apache-airflow-providers-openlineage) `apache-airflow-providers-openlineage`.
+
+##### Airflow 2.3 - 2.6
+
+The integration automatically registers itself starting from Airflow 2.3 if it's installed on the Airflow worker's Python.
+This means you don't have to do anything besides configuring where the events are sent, which is described in the [configuration](#configuration) section.
+
+##### Airflow 2.1 - 2.2
+
+Integration for those versions has limitations: it does not support tracking failed jobs, 
+and job starts are registered only when a job ends (a `LineageBackend`-based approach collects all metadata 
+for a task on each task's completion).
 
 To make OpenLineage work, in addition to installing `openlineage-airflow` you need to set your `LineageBackend` 
-in your `airflow.cfg` or via environmental variable `AIRFLOW__LINEAGE__BACKEND` to
+in your [airflow.cfg](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) or via environmental variable `AIRFLOW__LINEAGE__BACKEND` to
 
 ```
 openlineage.lineage_backend.OpenLineageBackend
 ```
 
-## Airflow <2.1 
+The OpenLineageBackend does not take into account manually configured inlets and outlets. 
+
+##### Airflow <2.1 
 
 OpenLineage does not work with versions older than Airflow 2.1.

--- a/docs/integrations/airflow/usage.md
+++ b/docs/integrations/airflow/usage.md
@@ -4,45 +4,74 @@ title: Using the Airflow Integration
 ---
 
 :::caution
-This page is about Airflow's external integration that works mainly for Airflow versions <2.7.
-[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)
+This page is about Airflow's external integration that works mainly for Airflow versions <2.7. 
+[If you're using Airflow 2.7+, look at native Airflow OpenLineage provider documentation.](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html)  <br /><br /> 
+
+The ongoing development and enhancements will be focused on the `apache-airflow-providers-openlineage` package, 
+while the `openlineage-airflow` will primarily be updated for bug fixes. See [all Airflow versions supported by this integration](older.md#supported-airflow-versions)
 :::
 
 #### PREREQUISITES
+
+- [Python 3.8](https://www.python.org/downloads)
+- [Airflow >= 2.1,<2.8](https://pypi.org/project/apache-airflow)
 
 To use the OpenLineage Airflow integration, you'll need a running [Airflow instance](https://airflow.apache.org/docs/apache-airflow/stable/start.html). You'll also need an OpenLineage-compatible [backend](https://github.com/OpenLineage/OpenLineage#scope).
 
 #### INSTALLATION
 
-To download and install the latest `openlineage-airflow` library, update the `requirements.txt` file of your running Airflow instance with: 
+Before installing check [supported Airflow versions](older.md#supported-airflow-versions).
+
+To download and install the latest `openlineage-airflow` library run: 
 
 ```
 openlineage-airflow
 ```
 
+You can also add `openlineage-airflow` to your `requirements.txt` for Airflow.  
+
+To install from source, run:
+
+```bash
+$ python3 setup.py install
+```
+
 #### CONFIGURATION
 
-Next, specify where you want OpenLineage to send events. There are a few options.
-The simplest one is to use the `OPENLINEAGE_URL` environment variable.
+Next, specify where you want OpenLineage to send events. 
+
+We recommend configuring the client with an `openlineage.yml` file that tells the client how to connect to an OpenLineage backend.  
+[See how to do it.](../../client/python.md#configuration)
+
+The simplest option, limited to HTTP client, is to use the environment variables.
 For example, to send OpenLineage events to a local instance of [Marquez](https://github.com/MarquezProject/marquez), use:
 
 ```bash
 OPENLINEAGE_URL=http://localhost:5000
+OPENLINEAGE_ENDPOINT=api/v1/lineage # This is the default value when this variable is not set, it can be omitted in this example
+OPENLINEAGE_API_KEY=secret_token # This is only required if authentication headers are required, it can be omitted in this example
 ```
 
-To set up an additional configuration, or to send events to targets other than an HTTP server (e.g., a Kafka topic), [configure a client.](../../client/python.md)
+To set up an additional configuration, or to send events to targets other than an HTTP server (e.g., a Kafka topic), [configure a client.](../../client/python.md#configuration)
 
-If you use a version of Airflow older than 2.3.0, [additional configuration is required](older.md).
+> **_NOTE:_** If you use a version of Airflow older than 2.3.0, [additional configuration is required](older.md#airflow-21---22).
 
-### Environment Variables
+##### Environment Variables
 
-The following environment variables are available specifically for the Airflow integration.
+The following environment variables are available specifically for the Airflow integration, in addition to [Python client variables](../../client/python.md#environment-variables).
 
-|Name|Description|Since|
-|---|---|---|
-|OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE|Set to `False` if you want source code of callables provided in PythonOperator or BashOperator `NOT` to be included in OpenLineage events.||
-|OPENLINEAGE_EXTRACTORS|The optional list of extractors class in case you need to use custom extractors.<br/>For example: `OPENLINEAGE_EXTRACTORS=full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass`||
-|OPENLINEAGE_NAMESPACE|The optional namespace that the lineage data belongs to. If not specified, defaults to `default`.||
+| Name                                    | Description                                                                                                                                | Example                                                        |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE | Set to `False` if you want source code of callables provided in PythonOperator or BashOperator `NOT` to be included in OpenLineage events. | False                                                          |
+| OPENLINEAGE_EXTRACTORS                  | The optional list of extractors class (as semi-colon separated string) in case you need to use custom extractors.                          | full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass |
+| OPENLINEAGE_NAMESPACE                   | The optional namespace that the lineage data belongs to. If not specified, defaults to `default`.                                          | my_namespace                                                   |
+| OPENLINEAGE_AIRFLOW_LOGGING             | Logging level of OpenLineage client in Airflow (the OPENLINEAGE_CLIENT_LOGGING variable from python client has no effect here).            | DEBUG                                                          |
+
+For backwards compatibility, `openlineage-airflow` also supports configuration via
+`MARQUEZ_NAMESPACE`, `MARQUEZ_URL` and `MARQUEZ_API_KEY` variables, instead of standard
+`OPENLINEAGE_NAMESPACE`, `OPENLINEAGE_URL` and `OPENLINEAGE_API_KEY`. 
+Variables with different prefix should not be mixed together.
+
 
 #### USAGE
 


### PR DESCRIPTION
Some docs were not up to date with what's possible in the code or what's included in README in the OL library. It should be much more current after this changes.

I am not sure if all the java updates are ok, but i took them from readme in library. Anyway, it would be nice if someone that's familiar with how java client works took a second look there.