### PR TITLE
Remove experimental note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # OpenLineage Docs
 
-NOTE: These docs are a work in progress. For current documentation, consult the various `README.md` files that can be found in the [OpenLineage Repository](https://github.com/OpenLineage/openlineage).
-
 This is a Docusaurus site, and all content can be found in `docs/`. Contributions are welcome in the form of issues or pull requests. Pages that require attention have been marked with Docusaurus Admonitions.
 
 ### New posts

--- a/docs/client/python.md
+++ b/docs/client/python.md
@@ -43,6 +43,8 @@ See the [example config file](#built-in-transport-types) for each transport type
 
 If there is no config file found, the OpenLineage client looks at environment variables for [HTTP transport](#http-transport-configuration-with-environment-variables).
 
+At the end, if no configuration is found, ``ConsoleTransport`` is used, the events are printed in the console.
+
 ### Environment Variables
 
 The following environment variables are available to use:  


### PR DESCRIPTION
As we are moving all the docs from README files in OL repo to this site, we should remove the note about the site being experimental.

Also added a small update in python page.