### PR TITLE
[SPARK] reorganise docs

### DIFF
--- a/docs/integrations/spark/configuration/_category_.json
+++ b/docs/integrations/spark/configuration/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Configuration",
+  "position": 2
+}

--- a/docs/integrations/spark/configuration/airflow.md
+++ b/docs/integrations/spark/configuration/airflow.md
@@ -1,0 +1,30 @@
+---
+sidebar_position: 4
+title: Scheduling from Airflow
+---
+
+
+The same parameters passed to `spark-submit` can be supplied from Airflow and other schedulers. If
+using the [openlineage-airflow](../../airflow/airflow.md) integration, each task in the DAG has its own Run id
+which can be connected to the Spark job run via the `spark.openlineage.parentRunId` parameter. For example,
+here is an example of a `DataProcPySparkOperator` that submits a Pyspark application on Dataproc:
+
+```python
+t1 = DataProcPySparkOperator(
+    task_id=job_name,
+    gcp_conn_id='google_cloud_default',
+    project_id='project_id',
+    cluster_name='cluster-name',
+    region='us-west1',
+    main='gs://bucket/your-prog.py',
+    job_name=job_name,
+    dataproc_pyspark_properties={
+      "spark.extraListeners": "io.openlineage.spark.agent.OpenLineageSparkListener",
+      "spark.jars.packages": "io.openlineage:openlineage-spark:1.0.0+",
+      "spark.openlineage.transport.url": f"{openlineage_url}/api/v1/namespaces/{openlineage_namespace}/jobs/dump_orders_to_gcs/runs/{{{{lineage_run_id(run_id, task)}}}}?api_key={api_key}",
+      "spark.openlineage.namespace": openlineage_namespace,
+      "spark.openlineage.parentJobName": job_name,
+      "spark.openlineage.parentRunId": f"{{{{lineage_run_id(run_id, task)}}}}
+    },
+    dag=dag)
+```

--- a/docs/integrations/spark/configuration/circuit_breaker.md
+++ b/docs/integrations/spark/configuration/circuit_breaker.md
@@ -1,0 +1,8 @@
+---
+sidebar_position: 3
+title: Circuit Breaker
+---
+
+import CircuitBreakers from '../../../client/java/partials/java_circuit_breaker.md';
+
+<CircuitBreakers/>

--- a/docs/integrations/spark/configuration/spark_conf.md
+++ b/docs/integrations/spark/configuration/spark_conf.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 2
+title: Spark Config Parameters
+---
+
+
+The following parameters can be specified:
+
+| Parameter                                          | Definition                                                                                                                                          | Example                             |
+----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
+| spark.openlineage.transport.type                   | The transport type used for event emit, default type is `console`                                                                                   | http                                |
+| spark.openlineage.namespace                        | The default namespace to be applied for any jobs submitted                                                                                          | MyNamespace                         |
+| spark.openlineage.parentJobName                    | The job name to be used for the parent job facet                                                                                                    | ParentJobName                       |
+| spark.openlineage.parentRunId                      | The RunId of the parent job that initiated this Spark job                                                                                           | xxxx-xxxx-xxxx-xxxx                 |
+| spark.openlineage.appName                          | Custom value overwriting Spark app name in events                                                                                                   | AppName                             |
+| spark.openlineage.facets.disabled                  | List of facets to disable, enclosed in `[]` (required from 0.21.x) and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
+| spark.openlineage.capturedProperties               | comma separated list of properties to be captured in spark properties facet (default `spark.master`, `spark.app.name`)                              | "spark.example1,spark.example2"     |
+| spark.openlineage.dataset.removePath.pattern       | Java regular expression that removes `?<remove>` named group from dataset path. Can be used to last path subdirectories from paths like `s3://my-whatever-path/year=2023/month=04` | `(.*)(?<remove>\/.*\/.*)`     |
+| spark.openlineage.jobName.appendDatasetName        | Decides whether output dataset name should be appended to job name. By default `true`.                                                                                             | false                               |
+| spark.openlineage.jobName.replaceDotWithUnderscore | Replaces dots in job name with underscore. Can be used to mimic legacy behaviour on Databricks platform. By default `false`.                                                       | false                               |
+| spark.openlineage.debugFacet                       | Determines whether debug facet shall be generated and included within the event. Set `enabled` to turn it on. By default, facet is disabled.                                       | enabled                             |

--- a/docs/integrations/spark/configuration/transport.md
+++ b/docs/integrations/spark/configuration/transport.md
@@ -1,0 +1,8 @@
+---
+sidebar_position: 2
+title: Transport
+---
+
+import Transports from '../../../client/java/partials/java_transport.md';
+
+<Transports/>

--- a/docs/integrations/spark/configuration/usage.md
+++ b/docs/integrations/spark/configuration/usage.md
@@ -1,7 +1,8 @@
 ---
-sidebar_position: 2
-title: Configuration
+sidebar_position: 1
+title: Usage
 ---
+
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -121,33 +122,3 @@ application at runtime, via the previously detailed methods. However, it is **st
 that more dynamic or quickly changing parameters like `spark.openlineage.parentRunId` or
 `spark.openlineage.parentJobName` be set at runtime via the CLI or `SparkSession#config` methods.
 :::
-
-#### Spark Config Parameters
-
-The following parameters can be specified:
-
-| Parameter                                          | Definition                                                                                                                                          | Example                             |
-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
-| spark.openlineage.transport.type                   | The transport type used for event emit, default type is `console`                                                                                   | http                                |
-| spark.openlineage.namespace                        | The default namespace to be applied for any jobs submitted                                                                                          | MyNamespace                         |
-| spark.openlineage.parentJobName                    | The job name to be used for the parent job facet                                                                                                    | ParentJobName                       |
-| spark.openlineage.parentRunId                      | The RunId of the parent job that initiated this Spark job                                                                                           | xxxx-xxxx-xxxx-xxxx                 |
-| spark.openlineage.appName                          | Custom value overwriting Spark app name in events                                                                                                   | AppName                             |
-| spark.openlineage.facets.disabled                  | List of facets to disable, enclosed in `[]` (required from 0.21.x) and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
-| spark.openlineage.capturedProperties               | comma separated list of properties to be captured in spark properties facet (default `spark.master`, `spark.app.name`)                              | "spark.example1,spark.example2"     |
-| spark.openlineage.dataset.removePath.pattern       | Java regular expression that removes `?<remove>` named group from dataset path. Can be used to last path subdirectories from paths like `s3://my-whatever-path/year=2023/month=04` | `(.*)(?<remove>\/.*\/.*)`     |
-| spark.openlineage.jobName.appendDatasetName        | Decides whether output dataset name should be appended to job name. By default `true`.                                                                                             | false                               |
-| spark.openlineage.jobName.replaceDotWithUnderscore | Replaces dots in job name with underscore. Can be used to mimic legacy behaviour on Databricks platform. By default `false`.                                                       | false                               |
-| spark.openlineage.debugFacet                       | Determines whether debug facet shall be generated and included within the event. Set `enabled` to turn it on. By default, facet is disabled.                                       | enabled                             |
-
-## Transports
-
-import Transports from '../../client/java/partials/java_transport.md';
-
-<Transports/>
-
-## Circuit Breakers
-
-import CircuitBreakers from '../../client/java/partials/java_circuit_breaker.md';
-
-<CircuitBreakers/>

--- a/docs/integrations/spark/installation.md
+++ b/docs/integrations/spark/installation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: Installation
 ---
 
@@ -27,7 +27,7 @@ To integrate OpenLineage Spark with your application, you can:
 
 :::info
 This approach does not demonstrate how to configure the `OpenLineageSparkListener`.
-Please refer to the [Configuration](./configuration.md) section.
+Please refer to the [Configuration](configuration/usage.md) section.
 :::
 
 For Maven, add the following to your `pom.xml`:

--- a/docs/integrations/spark/main_concept.md
+++ b/docs/integrations/spark/main_concept.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 1
+title: Main Concepts
+---
+
+Spark jobs typically run on clusters of machines. A single machine hosts the "driver" application,
+which constructs a graph of jobs - e.g., reading data from a source, filtering, transforming, and
+joining records, and writing results to some sink- and manages execution of those jobs. Spark's
+fundamental abstraction is the Resilient Distributed Dataset (RDD), which encapsulates distributed
+reads and modifications of records. While RDDs can be used directly, it is far more common to work
+with Spark Datasets or Dataframes, which is an API that adds explicit schemas for better performance
+and the ability to interact with datasets using SQL. The Dataframe's declarative API enables Spark
+to optimize jobs by analyzing and manipulating an abstract query plan prior to execution.
+
+## Collecting Lineage in Spark
+
+Collecting lineage requires hooking into Spark's `ListenerBus` in the driver application and
+collecting and analyzing execution events as they happen. Both raw RDD and Dataframe jobs post events
+to the listener bus during execution. These events expose the structure of the job, including the
+optimized query plan, allowing the Spark integration to analyze the job for datasets consumed and
+produced, including attributes about the storage, such as location in GCS or S3, table names in a
+relational database or warehouse, such as Redshift or Bigquery, and schemas. In addition to dataset
+and job lineage, Spark SQL jobs also report logical plans, which can be compared across job runs to
+track important changes in query plans, which may affect the correctness or speed of a job.
+
+A single Spark application may execute multiple jobs. The Spark OpenLineage integration maps one
+Spark job to a single OpenLineage Job. The application will be assigned a Run id at startup and each
+job that executes will report the application's Run id as its parent job run. Thus, an application
+that reads one or more source datasets, writes an intermediate dataset, then transforms that
+intermediate dataset and writes a final output dataset will report three jobs- the parent application
+job, the initial job that reads the sources and creates the intermediate dataset, and the final job
+that consumes the intermediate dataset and produces the final output. As an image:
+![image](./spark-job-creation.dot.png)

--- a/docs/integrations/spark/quickstart/quickstart_local.md
+++ b/docs/integrations/spark/quickstart/quickstart_local.md
@@ -5,7 +5,9 @@ title: Quickstart with Jupyter
 
 Trying out the Spark integration is super easy if you already have Docker Desktop and git installed. 
 
-Note: If you're on macOS Monterey (macOS 12) you'll have to release port 5000 before beginning by disabling the [AirPlay Receiver](https://developer.apple.com/forums/thread/682332).
+:::info
+If you're on macOS Monterey (macOS 12) you'll have to release port 5000 before beginning by disabling the [AirPlay Receiver](https://developer.apple.com/forums/thread/682332).
+:::
 
 Check out the OpenLineage project into your workspace with:
 ```

--- a/docs/integrations/spark/spark.md
+++ b/docs/integrations/spark/spark.md
@@ -4,74 +4,13 @@ title: Apache Spark
 ---
 
 :::info
-This integration is known to work with Apache Spark 2.4 and later.
+This integration is known to work with latest Spark versions as well as Apache Spark 2.4.
+Please refer [here](https://github.com/OpenLineage/OpenLineage/tree/main/integration#openlineage-integrations)
+for up-to-date information on versions supported.
 :::
-
-Spark jobs typically run on clusters of machines. A single machine hosts the "driver" application,
-which constructs a graph of jobs - e.g., reading data from a source, filtering, transforming, and
-joining records, and writing results to some sink- and manages execution of those jobs. Spark's
-fundamental abstraction is the Resilient Distributed Dataset (RDD), which encapsulates distributed
-reads and modifications of records. While RDDs can be used directly, it is far more common to work
-with Spark Datasets or Dataframes, which is an API that adds explicit schemas for better performance
-and the ability to interact with datasets using SQL. The Dataframe's declarative API enables Spark
-to optimize jobs by analyzing and manipulating an abstract query plan prior to execution.
-
-## Collecting Lineage in Spark
-
-Collecting lineage requires hooking into Spark's `ListenerBus` in the driver application and
-collecting and analyzing execution events as they happen. Both raw RDD and Dataframe jobs post events
-to the listener bus during execution. These events expose the structure of the job, including the
-optimized query plan, allowing the Spark integration to analyze the job for datasets consumed and
-produced, including attributes about the storage, such as location in GCS or S3, table names in a
-relational database or warehouse, such as Redshift or Bigquery, and schemas. In addition to dataset
-and job lineage, Spark SQL jobs also report logical plans, which can be compared across job runs to
-track important changes in query plans, which may affect the correctness or speed of a job.
-
-A single Spark application may execute multiple jobs. The Spark OpenLineage integration maps one
-Spark job to a single OpenLineage Job. The application will be assigned a Run id at startup and each
-job that executes will report the application's Run id as its parent job run. Thus, an application
-that reads one or more source datasets, writes an intermediate dataset, then transforms that
-intermediate dataset and writes a final output dataset will report three jobs- the parent application
-job, the initial job that reads the sources and creates the intermediate dataset, and the final job
-that consumes the intermediate dataset and produces the final output. As an image:
-![image](./spark-job-creation.dot.png)
-
-## About the Integration
 
 This integration employs the `SparkListener` interface through `OpenLineageSparkListener`, offering
 a comprehensive monitoring solution. It examines SparkContext-emitted events to extract metadata
 associated with jobs and datasets, utilizing the RDD and DataFrame dependency graphs. This method
 effectively gathers information from various data sources, including filesystem sources (e.g., S3
 and GCS), JDBC backends, and data warehouses such as Redshift and Bigquery.
-
-## How to Use the Integration
-
-Incorporating OpenLineage metadata collection into existing Spark jobs is designed to be simple and
-minimally invasive.
-
-### Scheduling from Airflow
-
-The same parameters passed to `spark-submit` can be supplied from Airflow and other schedulers. If
-using the [openlineage-airflow](../airflow/airflow.md) integration, each task in the DAG has its own Run id
-which can be connected to the Spark job run via the `spark.openlineage.parentRunId` parameter. For example,
-here is an example of a `DataProcPySparkOperator` that submits a Pyspark application on Dataproc:
-
-```python
-t1 = DataProcPySparkOperator(
-    task_id=job_name,
-    gcp_conn_id='google_cloud_default',
-    project_id='project_id',
-    cluster_name='cluster-name',
-    region='us-west1',
-    main='gs://bucket/your-prog.py',
-    job_name=job_name,
-    dataproc_pyspark_properties={
-      "spark.extraListeners": "io.openlineage.spark.agent.OpenLineageSparkListener",
-      "spark.jars.packages": "io.openlineage:openlineage-spark:1.0.0+",
-      "spark.openlineage.transport.url": f"{openlineage_url}/api/v1/namespaces/{openlineage_namespace}/jobs/dump_orders_to_gcs/runs/{{{{lineage_run_id(run_id, task)}}}}?api_key={api_key}",
-      "spark.openlineage.namespace": openlineage_namespace,
-      "spark.openlineage.parentJobName": job_name,
-      "spark.openlineage.parentRunId": f"{{{{lineage_run_id(run_id, task)}}}}
-    },
-    dag=dag)
-```


### PR DESCRIPTION
* reorganise welcome page for spark documentation by moving content to `main concepts` page
* split configuration page to multiple pages