### PR TITLE
fix broken links; update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# intellij
+.idea

--- a/docs/development/ol-proxy.md
+++ b/docs/development/ol-proxy.md
@@ -11,7 +11,7 @@ When you are unable to collect logs on the client side, but want to make sure th
 OpenLineage proxy can be obtained via github:
 ```
 git clone https://github.com/OpenLineage/OpenLineage.git
-cd OpenLineage/proxy
+cd OpenLineage/proxy/backend
 ```
 
 ## Building the proxy
@@ -24,7 +24,7 @@ The packaged jar file can be found under `./build/libs/`
 
 ## Running the proxy
 
-OpenLineage Proxy requires configuration file named `proxy.yml`. There is an [example](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/proxy.example.yml) that you can copy and name it as `proxy.yml`.
+OpenLineage Proxy requires configuration file named `proxy.yml`. There is an [example](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/backend/proxy.example.yml) that you can copy and name it as `proxy.yml`.
 
 ```
 cp proxy.example.yml proxy.yml
@@ -52,6 +52,6 @@ Once the message is sent to the proxy, you will see the OpenLineage message cont
 Not only the OpenLineage proxy is useful in receiving the monitoring the OpenLineage events, it can also be used to relay the events to other endpoints. Please see the [example](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/proxy.example.yml) of how to set the proxy to relay the events via Kafka topic or HTTP endpoint.
 
 ## Other ways to run OpenLineage Proxy
-- You do not have to clone the git repo and build all the time. OpenLineage proxy is published and available in [Maven Repository](https://mvnrepository.com/artifact/io.openlineage/openlineage-proxy/0.14.1).
-- You can also run OpenLineage Proxy as a [docker container](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/Dockerfile).
-- There is also a [helm chart for Kubernetes](https://github.com/OpenLineage/OpenLineage/tree/main/proxy/chart) available.
+- You do not have to clone the git repo and build all the time. OpenLineage proxy is published and available in [Maven Repository](https://mvnrepository.com/artifact/io.openlineage/openlineage-proxy/).
+- You can also run OpenLineage Proxy as a [docker container](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/backend/Dockerfile).
+- There is also a [helm chart for Kubernetes](https://github.com/OpenLineage/OpenLineage/tree/main/proxy/backend/chart) available.

--- a/docs/development/ol-proxy.md
+++ b/docs/development/ol-proxy.md
@@ -49,7 +49,7 @@ Once the message is sent to the proxy, you will see the OpenLineage message cont
 > You might have noticed that OpenLineage client (python, java) simply requires `http://localhost:8080` as the URL endpoint. This is possible because the client code adds the `/api/v1/lineage` internally before it makes the request. If you are not using OpenLineage client library to emit OpenLineage events, you must use the full URL in order for the proxy to receive the data correctly.
 
 ## Forwarding the data
-Not only the OpenLineage proxy is useful in receiving the monitoring the OpenLineage events, it can also be used to relay the events to other endpoints. Please see the [example](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/proxy.example.yml) of how to set the proxy to relay the events via Kafka topic or HTTP endpoint.
+Not only the OpenLineage proxy is useful in receiving the monitoring the OpenLineage events, it can also be used to relay the events to other endpoints. Please see the [example](https://github.com/OpenLineage/OpenLineage/blob/main/proxy/backend/proxy.example.yml) of how to set the proxy to relay the events via Kafka topic or HTTP endpoint.
 
 ## Other ways to run OpenLineage Proxy
 - You do not have to clone the git repo and build all the time. OpenLineage proxy is published and available in [Maven Repository](https://mvnrepository.com/artifact/io.openlineage/openlineage-proxy/).


### PR DESCRIPTION
Hi,

The OpenLineage proxy page has several broken links.  This PR should fix them.  Please let me know if anything needs to be further updated. 