### PR TITLE
Improve transport configuration docs

### DIFF
--- a/docs/client/java/configuration.md
+++ b/docs/client/java/configuration.md
@@ -15,7 +15,7 @@ You can make this file available to the client in three ways (the list also pres
 3. Place an `openlineage.yml` under `.openlineage/` in the user's home directory (`~/.openlineage/openlineage.yml`).
 
 
-### Environment Variables
+## Environment Variables
 The following environment variables are available:
 
 | Name                 | Description                                                                 | Since |
@@ -24,7 +24,7 @@ The following environment variables are available:
 | OPENLINEAGE_DISABLED | When `true`, OpenLineage will not emit events.                              | 0.9.0 |
 
 
-### Facets Configuration
+## Facets Configuration
 
 In YAML configuration file you can also specify a list of disabled facets that will not be included in OpenLineage event.
 
@@ -38,7 +38,7 @@ facets:
     - spark_logicalPlan
 ```
 
-### Transports
+## Transports
 
 import Transports from './partials/java_transport.md';
 

--- a/docs/client/java/java.md
+++ b/docs/client/java/java.md
@@ -24,14 +24,14 @@ Maven:
 <dependency>
     <groupId>io.openlineage</groupId>
     <artifactId>openlineage-java</artifactId>
-    <version>1.8.0</version>
+    <version>${OPENLINEAGE_VERSION}</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```groovy
-implementation 'io.openlineage:openlineage-java:1.8.0'
+implementation("io.openlineage:openlineage-java:${OPENLINEAGE_VERSION}")
 ```
 
 For more information on the available versions of the `openlineage-java`, 

--- a/docs/client/java/partials/java_transport.md
+++ b/docs/client/java/partials/java_transport.md
@@ -5,10 +5,30 @@ import TabItem from '@theme/TabItem';
 
 ### [HTTP](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java)
 
-Allows sending events to HTTP endpoint (with optional authorization headers).
+Allows sending events to HTTP endpoint, using [ApacheHTTPClient](https://hc.apache.org/index.html).
 
-<Tabs groupId="spark">
-<TabItem value="Yaml Config" label="Yaml Config">
+#### Configuration
+
+- `type` - string, must be `"http"`. Required.
+- `url` - string, base url for HTTP requests. Required.
+- `endpoint` - string specifying the endpoint to which events are sent, appended to `url`. Optional, default: `/api/v1/lineage`.
+- `urlParams` - dictionary specifying query parameters send in HTTP requests. Optional.
+- `timeoutInMillis` - integer specifying timeout (in milliseconds) value used while connecting to server. Optional, default: `5000`.
+- `auth` - dictionary specifying authentication options. Optional, by default no authorization is used. If set, requires the `type` property.
+  - `type` - string specifying the "api_key" or the fully qualified class name of your TokenProvider. Required if `auth` is provided.
+  - `apiKey` - string setting the Authentication HTTP header as the Bearer. Required if `type` is `api_key`.
+- `headers` - dictionary specifying HTTP request headers. Optional.
+
+#### Behavior
+
+Events are serialized to JSON, and then are send as HTTP POST request with `Content-Type: application/json`.
+
+#### Examples
+
+<Tabs groupId="integrations">
+<TabItem value="yaml" label="Yaml Config">
+
+Anonymous connection:
 
 ```yaml
 transport:
@@ -22,74 +42,64 @@ With authorization:
 transport:
   type: http
   url: http://localhost:5000
-  endpoint: api/v1/lineage
   auth:
     type: api_key
     api_key: f38d2189-c603-4b46-bdea-e573a3b5a7d5
 ```
 
-<details><summary>Override the default configuration of the HttpTransport within Java client</summary>
-<p>
+Full example:
 
-#### Overriden default configuration of the `HttpTransport`
-
-You can override the default configuration of the `HttpTransport` by specifying the URL and API key when
-creating a new client:
-
-```java
-OpenLineageClient client = OpenLineageClient.builder()
-  .transport(
-    HttpTransport.builder()
-      .url("http://localhost:5000")
-      .apiKey("f38d2189-c603-4b46-bdea-e573a3b5a7d5")
-      .build())
-  .build();
+```yaml
+transport:
+  type: http
+  url: http://localhost:5000
+  endpoint: /api/v1/lineage
+  urlParams:
+    param0: value0
+    param1: value1
+  timeoutInMillis: 5000
+  auth:
+    type: api_key
+    api_key: f38d2189-c603-4b46-bdea-e573a3b5a7d5
+  headers:
+    X-Some-Extra-Header: abc
 ```
-
-To configure the client with query params appended on each HTTP request, use:
-
-```java
-Map<String, String> queryParamsToAppend = Map.of(
-  "param0","value0",
-  "param1", "value1"
-);
-
-// Connect to http://localhost:5000
-OpenLineageClient client = OpenLineageClient.builder()
-  .transport(
-    HttpTransport.builder()
-      .url("http://localhost:5000", queryParamsToAppend)
-      .apiKey("f38d2189-c603-4b46-bdea-e573a3b5a7d5")
-      .build())
-  .build();
-
-// Define a simple OpenLineage START or COMPLETE event
-OpenLineage.RunEvent startOrCompleteRun = ...
-
-// Emit OpenLineage event to http://localhost:5000/api/v1/lineage?param0=value0&param1=value1
-client.emit(startOrCompleteRun);
-```
-
-</p>
-</details>
 
 </TabItem>
-<TabItem value="Spark Config" label="Spark Config">
+<TabItem value="spark" label="Spark Config">
 
-| Parameter                                   | Definition                                                                                                                                  | Example               |
----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------
-| spark.openlineage.transport.endpoint        | Path to resource                                                                                                                            | /api/v1/lineage       |
-| spark.openlineage.transport.auth.type       | The type of authentication method to use                                                                                                    | api_key               |
-| spark.openlineage.transport.auth.apiKey     | An API key to be used when sending events to the OpenLineage server                                                                         | abcdefghijk           |
-| spark.openlineage.transport.timeoutInMillis | Timeout for sending OpenLineage info in milliseconds                                                                                        | 5000                  |
-| spark.openlineage.transport.urlParams.xyz   | A URL parameter (replace xyz) and value to be included in requests to the OpenLineage API server                                            | abcdefghijk           |
-| spark.openlineage.transport.url             | The hostname of the OpenLineage API server where events should be reported, it can have other properties embeded                            | http://localhost:5000 |
-| spark.openlineage.transport.headers.xyz     | Request headers (replace xyz) and value to be included in requests to the OpenLineage API server                                            | abcdefghijk           |
+Anonymous connection:
+
+```ini
+spark.openlineage.transport.type=http
+spark.openlineage.transport.url=http://localhost:5000
+```
+
+With authorization:
+
+```ini
+spark.openlineage.transport.type=http
+spark.openlineage.transport.url=http://localhost:5000
+spark.openlineage.transport.auth.type=api_key
+spark.openlineage.transport.auth.apiKey=f38d2189-c603-4b46-bdea-e573a3b5a7d5
+```
+
+Full example:
+
+```ini
+spark.openlineage.transport.type=http
+spark.openlineage.transport.url=http://localhost:5000
+spark.openlineage.transport.endpoint=/api/v1/lineage
+spark.openlineage.transport.urlParams.param0=value0
+spark.openlineage.transport.urlParams.param1=value1
+spark.openlineage.transport.timeoutInMillis=5000
+spark.openlineage.transport.auth.type=api_key
+spark.openlineage.transport.auth.apiKey=f38d2189-c603-4b46-bdea-e573a3b5a7d5
+spark.openlineage.transport.headers.X-Some-Extra-Header=abc
+```
 
 <details><summary>URL parsing within Spark integration</summary>
 <p>
-
-#### URL parsing within Spark integration
 
 You can supply http parameters using values in url, the parsed `spark.openlineage.*` properties are located in url as follows:
 
@@ -101,18 +111,115 @@ example:
 
 </p>
 </details>
-</TabItem>
-<TabItem value="Flink Config" label="Flink Config">
 
-| Parameter                                    | Definition                                                                                                                                  | Example               |
-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------
-| openlineage.transport.endpoint          | Path to resource                                                                                                                            | /api/v1/lineage       |
-| openlineage.transport.auth.type         | The type of authentication method to use                                                                                                    | api_key               |
-| openlineage.transport.auth.apiKey       | An API key to be used when sending events to the OpenLineage server                                                                         | abcdefghijk           |
-| openlineage.transport.timeout           | Timeout for sending OpenLineage info in milliseconds                                                                                        | 5000                  |
-| openlineage.transport.urlParams.xyz     | A URL parameter (replace xyz) and value to be included in requests to the OpenLineage API server                                            | abcdefghijk           |
-| openlineage.transport.url               | The hostname of the OpenLineage API server where events should be reported, it can have other properties embeded                            | http://localhost:5000 |
-| openlineage.transport.headers.xyz       | Request headers (replace xyz) and value to be included in requests to the OpenLineage API server                                            | abcdefghijk           |
+</TabItem>
+<TabItem value="flink" label="Flink Config">
+
+Anonymous connection:
+
+```ini
+spark.openlineage.transport.type=http
+spark.openlineage.transport.url=http://localhost:5000
+```
+
+With authorization:
+
+```ini
+openlineage.transport.type=http
+openlineage.transport.url=http://localhost:5000
+openlineage.transport.auth.type=api_key
+openlineage.transport.auth.apiKey=f38d2189-c603-4b46-bdea-e573a3b5a7d5
+```
+
+Full example:
+
+```ini
+openlineage.transport.type=http
+openlineage.transport.url=http://localhost:5000
+openlineage.transport.endpoint=/api/v1/lineage
+openlineage.transport.urlParams.param0=value0
+openlineage.transport.urlParams.param1=value1
+openlineage.transport.timeoutInMillis=5000
+openlineage.transport.auth.type=api_key
+openlineage.transport.auth.apiKey=f38d2189-c603-4b46-bdea-e573a3b5a7d5
+openlineage.transport.headers.X-Some-Extra-Header=abc
+```
+
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+Anonymous connection:
+
+```java
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.HttpConfig;
+import io.openlineage.client.transports.HttpTransport;
+
+HttpConfig httpConfig = new HttpConfig();
+httpConfig.setUrl("http://localhost:5000");
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new HttpTransport(httpConfig))
+  .build();
+```
+
+With authorization:
+
+```java
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.ApiKeyTokenProvider;
+import io.openlineage.client.transports.HttpConfig;
+import io.openlineage.client.transports.HttpTransport;
+
+ApiKeyTokenProvider apiKeyTokenProvider = new ApiKeyTokenProvider();
+apiKeyTokenProvider.setApiKey("f38d2189-c603-4b46-bdea-e573a3b5a7d5");
+
+HttpConfig httpConfig = new HttpConfig();
+httpConfig.setUrl("http://localhost:5000");
+httpConfig.setAuth(apiKeyTokenProvider);
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new HttpTransport(httpConfig))
+  .build();
+```
+
+Full example:
+
+```java
+import java.util.Map;
+
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.ApiKeyTokenProvider;
+import io.openlineage.client.transports.HttpConfig;
+import io.openlineage.client.transports.HttpTransport;
+
+Map<String, String> queryParams = Map.of(
+    "param0", "value0",
+    "param1", "value1"
+);
+
+Map<String, String> headers = Map.of(
+  "X-Some-Extra-Header", "abc"
+);
+
+ApiKeyTokenProvider apiKeyTokenProvider = new ApiKeyTokenProvider();
+apiKeyTokenProvider.setApiKey("f38d2189-c603-4b46-bdea-e573a3b5a7d5");
+
+HttpConfig httpConfig = new HttpConfig();
+httpConfig.setUrl("http://localhost:5000");
+httpConfig.setEndpoint("/api/v1/lineage");
+httpConfig.setUrlParams(queryParams);
+httpConfig.setAuth(apiKeyTokenProvider);
+httpConfig.setTimeoutInMillis(headers);
+httpConfig.setHeaders(5000);
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new HttpTransport(httpConfig))
+  .build();
+```
 
 </TabItem>
 </Tabs>
@@ -121,6 +228,18 @@ example:
 If a transport type is set to `kafka`, then the below parameters would be read and used when building KafkaProducer.
 This transport requires the artifact `org.apache.kafka:kafka-clients:3.1.0` (or compatible) on your classpath.
 
+#### Configuration
+
+- `type` - string, must be `"kafka"`. Required.
+- `topicName` - string specifying the topic on what events will be sent. Required.
+- `localServerId` - string, id of local server. Required.
+- `properties` - a dictionary containing a Kafka producer config as in [Kafka producer config](http://kafka.apache.org/0100/documentation.html#producerconfigs). Required.
+
+#### Behavior
+
+Events are serialized to JSON, and then dispatched to the Kafka topic.
+
+#### Examples
 
 <Tabs groupId="integrations">
 <TabItem value="yaml" label="Yaml Config">
@@ -129,37 +248,96 @@ This transport requires the artifact `org.apache.kafka:kafka-clients:3.1.0` (or 
 transport:
   type: kafka
   topicName: openlineage.events
-  # Kafka properties (see: http://kafka.apache.org/0100/documentation.html#producerconfigs)
   properties:
     bootstrap.servers: localhost:9092,another.host:9092
     acks: all
     retries: 3
     key.serializer: org.apache.kafka.common.serialization.StringSerializer
     value.serializer: org.apache.kafka.common.serialization.StringSerializer
+  localServerId: some-value
 ```
 
 </TabItem>
 <TabItem value="spark" label="Spark Config">
 
-| Parameter                                    | Definition                                      | Example    |
-----------------------------------------------|-------------------------------------------------|------------
-| spark.openlineage.transport.topicName        | Required, name of the topic                     | topic-name |
-| spark.openlineage.transport.localServerId    | Required, id of local server                    | xxxxxxxx   |
-| spark.openlineage.transport.properties.[xxx] | Optional, the [xxx] is property of Kafka client | 1          |
+```ini
+spark.openlineage.transport.type=kafka
+spark.openlineage.transport.topicName=openlineage.events
+spark.openlineage.transport.localServerId=xxxxxxxx
+spark.openlineage.transport.properties.bootstrap.servers=localhost:9092,another.host:9092
+spark.openlineage.transport.properties.acks=all
+spark.openlineage.transport.properties.retries=3
+spark.openlineage.transport.properties.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+spark.openlineage.transport.properties.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+spark.openlineage.transport.properties.localServerId=some-value
+```
+
 </TabItem>
 <TabItem value="flink" label="Flink Config">
 
-| Parameter                                    | Definition                                      | Example    |
-----------------------------------------------|-------------------------------------------------|------------
-| openlineage.transport.topicName        | Required, name of the topic                     | topic-name |
-| openlineage.transport.localServerId    | Required, id of local server                    | xxxxxxxx   |
-| openlineage.transport.properties.[xxx] | Optional, the [xxx] is property of Kafka client | 1          |
+```ini
+openlineage.transport.type=kafka
+openlineage.transport.topicName=openlineage.events
+openlineage.transport.localServerId=xxxxxxxx
+openlineage.transport.properties.bootstrap.servers=localhost:9092,another.host:9092
+openlineage.transport.properties.acks=all
+openlineage.transport.properties.retries=3
+openlineage.transport.properties.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+openlineage.transport.properties.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+openlineage.transport.properties.localServerId=some-value
+```
+
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+```java
+import java.util.Properties;
+
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.KafkaConfig;
+import io.openlineage.client.transports.KafkaTransport;
+
+Properties kafkaProperties = new Properties();
+kafkaProperties.setProperty("bootstrap.servers", "localhost:9092,another.host:9092");
+kafkaProperties.setProperty("acks", "all");
+kafkaProperties.setProperty("retries", "3");
+kafkaProperties.setProperty("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+kafkaProperties.setProperty("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+KafkaConfig kafkaConfig = new KafkaConfig();
+KafkaConfig.setTopicName("openlineage.events");
+KafkaConfig.setProperties(kafkaProperties);
+KafkaConfig.setLocalServerId("some-value");
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new KafkaTransport(httpConfig))
+  .build();
+```
+
 </TabItem>
 </Tabs>
 
 ### [Kinesis](https://github.com/OpenLineage/OpenLineage/blob/main/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java)
+
 If a transport type is set to `kinesis`, then the below parameters would be read and used when building KinesisProducer.
 Also, KinesisTransport depends on you to provide artifact `com.amazonaws:amazon-kinesis-producer:0.14.0` or compatible on your classpath.
+
+#### Configuration
+
+- `type` - string, must be `"kinesis"`. Required.
+- `streamName` - the streamName of the Kinesis. Required.
+- `region` - the region of the Kinesis. Required.
+- `roleArn` - the roleArn which is allowed to read/write to Kinesis stream. Optional.
+- `properties` - a dictionary that contains a [Kinesis allowed properties](https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties). Optional.
+
+#### Behavior
+
+- Events are serialized to JSON, and then dispatched to the Kinesis stream.
+- The partition key is generated as `{jobNamespace}:{jobName}`.
+- Two constructors are available: one accepting both `KinesisProducer` and `KinesisConfig` and another solely accepting `KinesisConfig`.
+
+#### Examples
 
 <Tabs groupId="integrations">
 <TabItem value="yaml" label="Yaml Config">
@@ -168,49 +346,84 @@ Also, KinesisTransport depends on you to provide artifact `com.amazonaws:amazon-
 transport:
   type: kinesis
   streamName: your_kinesis_stream_name
-  topicName: openlineage.events
   region: your_aws_region
-  roleArn: arn:aws:iam::account-id:role/role-name   # optional
-  properties:  # Refer to amazon-kinesis-producer's default configuration.md for the available properties
-    property_name_1: value_1
-    property_name_2: value_2
+  roleArn: arn:aws:iam::account-id:role/role-name
+  properties:
+    VerifyCertificate: true
+    ConnectTimeout: 6000
 ```
 
 </TabItem>
 <TabItem value="spark" label="Spark Config">
 
-| Parameter                                     | Definition                                                                                                                                                                                   | Example          |
------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------
-| spark.openlineage.transport.streamName        | Required, the streamName of the Kinesis Stream                                                                                                                                               | some-stream-name |
-| spark.openlineage.transport.region            | Required, the region of the stream                                                                                                                                                           | us-east-2        |
-| spark.openlineage.transport.roleArn           | Optional, the roleArn which is allowed to read/write to Kinesis stream                                                                                                                       | some-role-arn    |
-| spark.openlineage.transport.properties.[xxx]  | Optional, the [xxx] is property of [Kinesis allowd properties](https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties) | 1                |
+```ini
+spark.openlineage.transport.type=kinesis
+spark.openlineage.transport.streamName=your_kinesis_stream_name
+spark.openlineage.transport.region=your_aws_region
+spark.openlineage.transport.roleArn=arn:aws:iam::account-id:role/role-name
+spark.openlineage.transport.properties.VerifyCertificate=true
+spark.openlineage.transport.properties.ConnectTimeout=6000
+```
 
 </TabItem>
 <TabItem value="flink" label="Flink Config">
 
-| Parameter                                     | Definition                                                                                                                                                                                   | Example          |
------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------
-| openlineage.transport.streamName        | Required, the streamName of the Kinesis Stream                                                                                                                                               | some-stream-name |
-| openlineage.transport.region            | Required, the region of the stream                                                                                                                                                           | us-east-2        |
-| openlineage.transport.roleArn           | Optional, the roleArn which is allowed to read/write to Kinesis stream                                                                                                                       | some-role-arn    |
-| openlineage.transport.properties.[xxx]  | Optional, the [xxx] is property of [Kinesis allowd properties](https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties) | 1                |
+```ini
+openlineage.transport.type=kinesis
+openlineage.transport.streamName=your_kinesis_stream_name
+openlineage.transport.region=your_aws_region
+openlineage.transport.roleArn=arn:aws:iam::account-id:role/role-name
+openlineage.transport.properties.VerifyCertificate=true
+openlineage.transport.properties.ConnectTimeout=6000
+```
 
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+```java
+import java.util.Properties;
+
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.KinesisConfig;
+import io.openlineage.client.transports.KinesisTransport;
+
+Properties kinesisProperties = new Properties();
+kinesisProperties.setProperty("property_name_1", "value_1");
+kinesisProperties.setProperty("property_name_2", "value_2");
+
+KinesisConfig kinesisConfig = new KinesisConfig();
+kinesisConfig.setStreamName("your_kinesis_stream_name");
+kinesisConfig.setRegion("your_aws_region");
+kinesisConfig.setRoleArn("arn:aws:iam::account-id:role/role-name");
+kinesisConfig.setProperties(kinesisProperties);
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new KinesisTransport(httpConfig))
+  .build();
+```
 
 </TabItem>
 </Tabs>
 
-*Behavior*:
-- Events are serialized to JSON upon the `emit()` call and dispatched to the Kinesis stream.
-- The partition key is generated by combining the job's namespace and name.
-- Two constructors are available: one accepting both `KinesisProducer` and `KinesisConfig` and another solely accepting `KinesisConfig`.
-
-
 ### [Console](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java)
 
 This straightforward transport emits OpenLineage events directly to the console through a logger.
-Be cautious when using the DEBUG log level, as it might result in double-logging due to the `OpenLineageClient` also logging.
 No additional configuration is required.
+
+#### Behavior
+
+Events are serialized to JSON. Then each event is logged with `INFO` level to logger with name `ConsoleTransport`.
+
+#### Notes
+
+Be cautious when using the `DEBUG` log level, as it might result in double-logging due to the `OpenLineageClient` also logging.
+
+#### Configuration
+
+- `type` - string, must be `"console"`. Required.
+
+#### Examples
 
 <Tabs groupId="integrations">
 <TabItem value="yaml" label="Yaml Config">
@@ -219,21 +432,61 @@ No additional configuration is required.
 transport:
   type: console
 ```
+
 </TabItem>
 <TabItem value="spark" label="Spark Config">
 
+```ini
+spark.openlineage.transport.type=console
+```
 
 </TabItem>
 <TabItem value="flink" label="Flink Config">
 
+```ini
+openlineage.transport.type=console
+```
+
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+```java
+import java.util.Properties;
+
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.ConsoleTransport;
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new ConsoleTransport())
+  .build();
+```
 
 </TabItem>
 </Tabs>
 
 ### [File](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java)
 
-Designed mainly for integration testing, the `FileTransport` appends OpenLineage events to a given file.
-Events are newline-separated, with all pre-existing newline characters within the event JSON removed.
+Designed mainly for integration testing, the `FileTransport` emits OpenLineage events to a given file.
+
+#### Configuration
+
+- `type` - string, must be `"file"`. Required.
+- `location` - string specifying the path of the file. Required.
+
+#### Behavior
+
+- If the target file is absent, it's created.
+- Events are serialized to JSON, and then appended to a file, separated by newlines.
+- Intrinsic newline characters within the event JSON are eliminated to ensure one-line events.
+
+#### Notes for Yarn/Kubernetes
+
+This transport type is pretty useless on Spark/Flink applications deployed to Yarn or Kubernetes cluster:
+- Each executor will write file to a local filesystem of Yarn container/K8s pod. So resulting file will be removed when such container/pod is destroyed.
+- Kubernetes persistent volumes are not destroyed after pod removal. But all the executors will write to the same network disk in parallel, producing a broken file.
+
+#### Examples
 
 <Tabs groupId="integrations">
 <TabItem value="yaml" label="Yaml Config">
@@ -241,26 +494,42 @@ Events are newline-separated, with all pre-existing newline characters within th
 ```yaml
 transport:
   type: file
-  location: /path/to/your/file.txt
+  location: /path/to/your/file
 ```
+
 </TabItem>
 <TabItem value="spark" label="Spark Config">
 
-| Parameter                            | Definition | Example          |
---------------------------------------|------------|------------------
-| spark.openlineage.transport.location | File path  | /path/to/your/file.txt |
+```ini
+spark.openlineage.transport.type=file
+spark.openlineage.transport.location=/path/to/your/filext
+```
 
 </TabItem>
 <TabItem value="flink" label="Flink Config">
 
-| Parameter                                     | Definition | Example          |
------------------------------------------------|------------|------------------
-| openlineage.transport.location        | File path  | /path/to/your/file.txt |
+```ini
+openlineage.transport.type=file
+openlineage.transport.location=/path/to/your/file
+```
+
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+```java
+import java.util.Properties;
+
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.FileConfig;
+import io.openlineage.client.transports.FileTransport;
+
+FileConfig fileConfig = new FileConfig("/path/to/your/file");
+
+OpenLineageClient client = OpenLineageClient.builder()
+  .transport(
+    new FileTransport(fileConfig))
+  .build();
+```
 
 </TabItem>
 </Tabs>
-
-*Notes*:
-- If the target file is absent, it's created.
-- Events are added to the file, separated by newlines.
-- Intrinsic newline characters within the event JSON are eliminated to ensure one-line events.


### PR DESCRIPTION
- Options of Java transport have duplicated description for Spark & Flink, and had no description for Yaml. Moved transport description to a common section.
- Update both Java and Python transport config description to match each other. Configuration options, behavior, examples and notes are described in separated sections. Option names are `monospaced`.
- Improve Spark & Flink examples to show all the described options. Including `type` which was missing before.
- Add Java & Python code examples for each transport type, not just for HTTP.
