### PR TITLE
fix: correct example for jobType facet

### DIFF
--- a/docs/spec/facets/job-facets/job-type.md
+++ b/docs/spec/facets/job-facets/job-type.md
@@ -16,16 +16,13 @@ Example:
     ...
     "job": {
         "facets": {
-			"jobType": {
-              "jobType": {
+            "jobType": {
                 "processingType": "BATCH",
                 "integration": "SPARK",
                 "jobType": "QUERY",
                 "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
                 "_schemaURL": "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json"
-              }
             }
-
         }
 	...
 }


### PR DESCRIPTION
The JSON example for `jobType` had an extra nested `jobType` element which made it invalid.