### PR TITLE
[AIRFLOW] Preflight check DAG - provider package version check for airflow 2.10 and above

### DIFF
--- a/docs/integrations/airflow/preflight-check-dag.md
+++ b/docs/integrations/airflow/preflight-check-dag.md
@@ -106,6 +106,10 @@ def validate_ol_installation() -> None:
         library_name = "apache-airflow-providers-openlineage"
 
     library_version = _get_installed_package_version(library_name)
+    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) <= Version("1.18.0"):
+        raise ValueError(
+            f"Airflow version `{airflow_version}` requires `{library_name}` version >=1.18.0. "
+        )
     if BYPASS_LATEST_VERSION_CHECK:
         log.info(f"Bypassing the latest version check for `{library_name}`")
         return

--- a/docs/integrations/airflow/preflight-check-dag.md
+++ b/docs/integrations/airflow/preflight-check-dag.md
@@ -106,9 +106,11 @@ def validate_ol_installation() -> None:
         library_name = "apache-airflow-providers-openlineage"
 
     library_version = _get_installed_package_version(library_name)
-    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) < Version("1.8.0"):
+    if Version(airflow_version) >= Version("2.10.0") and library_version < Version("1.8.0"):
         raise ValueError(
             f"Airflow version `{airflow_version}` requires `{library_name}` version >=1.8.0. "
+            f"Installed version: `{library_version}` "
+            f"Please upgrade the package using `pip install --upgrade {library_name}`"
         )
     if BYPASS_LATEST_VERSION_CHECK:
         log.info(f"Bypassing the latest version check for `{library_name}`")

--- a/docs/integrations/airflow/preflight-check-dag.md
+++ b/docs/integrations/airflow/preflight-check-dag.md
@@ -106,7 +106,7 @@ def validate_ol_installation() -> None:
         library_name = "apache-airflow-providers-openlineage"
 
     library_version = _get_installed_package_version(library_name)
-    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) <= Version("1.18.0"):
+    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) < Version("1.18.0"):
         raise ValueError(
             f"Airflow version `{airflow_version}` requires `{library_name}` version >=1.18.0. "
         )

--- a/docs/integrations/airflow/preflight-check-dag.md
+++ b/docs/integrations/airflow/preflight-check-dag.md
@@ -106,9 +106,9 @@ def validate_ol_installation() -> None:
         library_name = "apache-airflow-providers-openlineage"
 
     library_version = _get_installed_package_version(library_name)
-    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) < Version("1.18.0"):
+    if Version(airflow_version) >= Version("2.10.0") and Version(library_version) < Version("1.8.0"):
         raise ValueError(
-            f"Airflow version `{airflow_version}` requires `{library_name}` version >=1.18.0. "
+            f"Airflow version `{airflow_version}` requires `{library_name}` version >=1.8.0. "
         )
     if BYPASS_LATEST_VERSION_CHECK:
         log.info(f"Bypassing the latest version check for `{library_name}`")


### PR DESCRIPTION
As airflow version 2.10 requires OL provider package 1.8.0 or above
https://github.com/kacpermuda/airflow/blob/fe9159635fdad1346a36d0ebada7f4ace3b25873/airflow/providers/openlineage/CHANGELOG.rst?plain=1#L34

Linked issue - https://github.com/OpenLineage/docs/issues/337