### PR TITLE
Replace GA tag script with Docusaurus config implementation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,11 +146,6 @@ const config = {
       defer: true,
       'data-domain': 'openlineage.io',
     },
-    'js/google_analytics.js',
-    {
-      src: 'https://www.googletagmanager.com/gtag/js?id=G-QMTWMLMX4M',
-      async: true,
-    },
   ],
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,6 +81,10 @@ const config = {
           ],
           mdxPageComponent: '@theme/MDXPage',
         },
+        gtag: {
+          trackingID: 'G-QMTWMLMX4M',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],

--- a/static/js/google_analytics.js
+++ b/static/js/google_analytics.js
@@ -1,5 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'G-QMTWMLMX4M');


### PR DESCRIPTION
There is a native Docusaurus implementation option for GA tagging that will hopefully fix an issue with the tags that will soon break the analytics (according to Google).

This replaces the existing script with the native implementation recommended by Docusaurus.

Closes: https://github.com/OpenLineage/docs/issues/354