### PR TITLE
Display ordered list as decimal and make unordered lists style explicit.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -432,13 +432,13 @@ code .token-line {
 }
 
 .theme-doc-markdown ol {
-  list-style-type: inherit;
+  list-style-type: decimal;
   margin: 0 0 var(--ifm-list-margin);
   padding-left: var(--ifm-list-left-padding);
 }
 
 .theme-doc-markdown ul {
-  list-style-type: inherit;
+  list-style-type: disc;
   margin: 0 0 var(--ifm-list-margin);
   padding-left: var(--ifm-list-left-padding);
 }


### PR DESCRIPTION
When ordered lists have the property `list-style-type` set to `inherit`, they display as discs (at least in Chromium based browsers), since they have nothing to inherit from. I've also explicitly set the unordered lists style to `disc` as the `inherit` with no parent would render in a different way depending on the browser defaults.