### PR TITLE
Deprecation note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[!IMPORTANT]
-Deprecated in favor of the OpenLineage [monorepo](https://github.com/OpenLineage/OpenLineage/tree/main/website).
+> [!IMPORTANT]
+> Deprecated in favor of the OpenLineage [monorepo](https://github.com/OpenLineage/OpenLineage/tree/main/website).
 
 # OpenLineage Docs
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+:::info
+
+Deprecated in favor of the OpenLineage [monorepo](https://github.com/OpenLineage/OpenLineage/tree/main/website).
+
+:::
+
 # OpenLineage Docs
 
 [![Covered by Argos Visual Testing](https://argos-ci.com/badge.svg)](https://app.argos-ci.com/pawel-big-lebowski/docs/reference?utm_source=OpenLineage&utm_campaign=oss)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-:::info
-
+[!IMPORTANT]
 Deprecated in favor of the OpenLineage [monorepo](https://github.com/OpenLineage/OpenLineage/tree/main/website).
-
-:::
 
 # OpenLineage Docs
 


### PR DESCRIPTION
Adds a note to the readme before this is archived now that the monorepo has been implemented.